### PR TITLE
Revise workflow to run using v7.10.2

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -59,6 +59,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
 
     - name: Runs Elasticsearch
+      #TODO create a docker action: https://github.com/opensearch-project/opensearch-js/issues/72
       uses: elastic/elastic-github-actions/elasticsearch@master
       with:
         stack-version: 7.10.2
@@ -91,6 +92,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
 
     - name: Runs Elasticsearch
+      #TODO create a docker action: https://github.com/opensearch-project/opensearch-js/issues/72
       uses: elastic/elastic-github-actions/elasticsearch@master
       with:
         stack-version: 7.10.2


### PR DESCRIPTION
### Description
This PR removes codecov due to outdated token. This test will be restored
once the repo is public. This PR makes the workflow running for main by
using version 7.10.2.

Note: more explanations for codecov can be found in this [issue](https://github.com/opensearch-project/opensearch-js/issues/70)

### Issue Resolved:
https://github.com/opensearch-project/opensearch-js/issues/3

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

