### PR TITLE
[Bug][CI] Fix bundler support test bug for clean CI

### DIFF
--- a/test/bundlers/parcel-test/package.json
+++ b/test/bundlers/parcel-test/package.json
@@ -2,7 +2,7 @@
   "name": "parcel-test",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "index-result.js",
   "scripts": {
     "start": "node index.js",
     "build": "parcel build index.js --no-source-maps"


### PR DESCRIPTION
#### Description

Currently,bundler support test fails due to package source name
equal to package main name. This might cause package source file
index.js being overwritten. This PR simply change main to avoid the
overwritten risk.

#### Issue Resolved:
https://github.com/opensearch-project/opensearch-js/issues/85

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

