### PR TITLE
replace elastic url to opensearch url

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -14,7 +14,7 @@
       numToKeep: 100
     properties:
     - github:
-        url: https://github.com/elastic/elasticsearch-js/
+        url: https://github.com/opensearch-project/opensearch-js/
     - inject:
         properties-content: HOME=$JENKINS_HOME
     concurrent: true
@@ -26,7 +26,7 @@
         reference-repo: /var/lib/jenkins/.git-references/elasticsearch-js.git
         branches:
         - ${branch_specifier}
-        url: https://github.com/elastic/elasticsearch-js.git
+        url: https://github.com/opensearch-project/opensearch-js.git
         wipe-workspace: 'True'
     triggers:
     - github

--- a/api/kibana.d.ts
+++ b/api/kibana.d.ts
@@ -41,7 +41,7 @@ import * as T from './types'
 /**
   * We are still working on this type, it will arrive soon.
   * If it's critical for you, please open an issue.
-  * https://github.com/elastic/elasticsearch-js
+  * https://github.com/opensearch-project/opensearch-js
   */
 type TODO = Record<string, any>
 

--- a/api/new.d.ts
+++ b/api/new.d.ts
@@ -47,7 +47,7 @@ import * as T from './types'
 /**
   * We are still working on this type, it will arrive soon.
   * If it's critical for you, please open an issue.
-  * https://github.com/elastic/elasticsearch-js
+  * https://github.com/opensearch-project/opensearch-js
   */
 type TODO = Record<string, any>
 

--- a/docs/examples/proxy/api/autocomplete.js
+++ b/docs/examples/proxy/api/autocomplete.js
@@ -73,7 +73,7 @@ module.exports = async (req, res) => {
       body: {
         _source: ['id', 'url', 'name'], // the fields you want to show in the autocompletion
         size: 0,
-        // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html
+        // https://opensearch.org/docs/opensearch/ux/#autocomplete-queries
         suggest: {
           suggestions: {
             prefix: req.query.q,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "./": "./"
   },
-  "homepage": "http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html",
+  "homepage": "https://www.opensearch.org/",
   "version": "7.14.0",
   "versionCanary": "7.14.0-canary.6",
   "keywords": [
@@ -84,10 +84,10 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/elastic/elasticsearch-js.git"
+    "url": "https://github.com/opensearch-project/opensearch-js.git"
   },
   "bugs": {
-    "url": "https://github.com/elastic/elasticsearch-js/issues"
+    "url": "https://github.com/opensearch-project/opensearch-js/issues"
   },
   "engines": {
     "node": ">=12"

--- a/scripts/kibana-docker.sh
+++ b/scripts/kibana-docker.sh
@@ -2,7 +2,7 @@
 
 exec docker run \
   --rm \
-  -e ELASTICSEARCH_URL="http://elasticsearch:9200" \
+  -e ELASTICSEARCH_URL="http://opensearch:9200" \
   -p 5601:5601 \
   --network=elastic \
   docker.elastic.co/kibana/kibana:7.0.0

--- a/scripts/utils/clone-es.js
+++ b/scripts/utils/clone-es.js
@@ -23,7 +23,7 @@ const { accessSync, mkdirSync } = require('fs')
 const { join } = require('path')
 const Git = require('simple-git')
 
-const esRepo = 'https://github.com/elastic/elasticsearch.git'
+const esRepo = 'https://github.com/opensearch-project/opensearch-js.git'
 const esFolder = join(__dirname, '..', '..', 'elasticsearch')
 const apiFolder = join(esFolder, 'rest-api-spec', 'src', 'main', 'resources', 'rest-api-spec', 'api')
 

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -5,8 +5,8 @@
 Yes.
 
 ## Background
-Elasticsearch offers its entire API via HTTP REST endpoints. You can find the whole API specification for every version [here](https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/api).<br/>
-To support different languages at the same time, the Elasticsearch team decided to provide a [YAML specification](https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/test) to test every endpoint, body, headers, warning, error and so on.<br/>
+Elasticsearch offers its entire API via HTTP REST endpoints. You can find the whole API specification for every version [here](https://github.com/opensearch-project/OpenSearch/tree/main/rest-api-spec/src/main/resources/rest-api-spec/api).<br/>
+To support different languages at the same time, the Elasticsearch team decided to provide a [YAML specification](https://github.com/opensearch-project/OpenSearch/tree/main/rest-api-spec/src/main/resources/rest-api-spec/test) to test every endpoint, body, headers, warning, error and so on.<br/>
 This testing suite uses that specification to generate the test for the specified version of Elasticsearch on the fly.
 
 ## Run
@@ -46,7 +46,7 @@ At first sight, it might seem complicated, but once you understand what the movi
 
 Inside the `index.js` file, you will find the connection, cloning, reading and parsing part of the test, while inside the `test-runner.js` file you will find the function to handle the assertions. Inside `test-runner.js`, we use a [queue](https://github.com/delvedor/workq) to be sure that everything is run in the correct order.
 
-Checkout the [rest-api-spec readme](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc) if you want to know more about how the assertions work.
+Checkout the [rest-api-spec readme](https://github.com/opensearch-project/OpenSearch/blob/main/rest-api-spec/src/main/resources/rest-api-spec/test/README.md) if you want to know more about how the assertions work.
 
 #### Why are we running the test with the `--harmony` flag?
 Because on Node v6 the regex lookbehinds are not supported.


### PR DESCRIPTION
#### Description
This PR replaces es url to opensearch url. There are 3 things need some attentions: 1) It doesn't
change urls related to public issues/pulls.  2)In package.json, it changes homepage to "https://www.opensearch.org/" which might need to revise?? 3) In scripts/download-artifacts.js, for download artifacts the url is "https://artifacts-api.elastic.co/v1/versions/${version} " we need to check what is the replacement.

Here is the issue to trace later work: issue[#115](https://github.com/opensearch-project/opensearch-js/issues/115)


Signed-off-by: Anan Zhuang <ananzh@amazon.com>


#### Test
<img width="377" alt="Screen Shot 2021-08-06 at 12 50 15 PM" src="https://user-images.githubusercontent.com/79961084/128564180-6343939f-fbd6-4073-80e7-779a47fd667e.png">

