### PR TITLE
Remove x-elastic-client-meta header

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ class Client extends ESAPI {
       if (opts.compression == null) opts.compression = 'gzip'
       if (opts.suggestCompression == null) opts.suggestCompression = true
       if (opts.ssl == null ||
-         (opts.ssl && opts.ssl.secureProtocol == null)) {
+        (opts.ssl && opts.ssl.secureProtocol == null)) {
         opts.ssl = opts.ssl || {}
         opts.ssl.secureProtocol = 'TLSv1_2_method'
       }
@@ -135,10 +135,6 @@ class Client extends ESAPI {
     this[kExtensions] = []
     this.name = options.name
 
-    if (options.enableMetaHeader) {
-      options.headers['x-elastic-client-meta'] = `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion}`
-    }
-
     if (opts[kChild] !== undefined) {
       this.serializer = options[kChild].serializer
       this.connectionPool = options[kChild].connectionPool
@@ -158,8 +154,8 @@ class Client extends ESAPI {
         auth: options.auth,
         emit: this[kEventEmitter].emit.bind(this[kEventEmitter]),
         sniffEnabled: options.sniffInterval !== false ||
-                      options.sniffOnStart !== false ||
-                      options.sniffOnConnectionFault !== false
+          options.sniffOnStart !== false ||
+          options.sniffOnConnectionFault !== false
       })
       // Add the connections before initialize the Transport
       this.connectionPool.addConnection(options.node || options.nodes)

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -41,7 +41,7 @@ const sleep = promisify(setTimeout)
 const kClient = Symbol('elasticsearch-client')
 const kMetaHeader = Symbol('meta header')
 /* istanbul ignore next */
-const noop = () => {}
+const noop = () => { }
 
 class Helpers {
   constructor (opts) {
@@ -86,7 +86,6 @@ class Helpers {
   async * scrollSearch (params, options = {}) {
     if (this[kMetaHeader] !== null) {
       options.headers = options.headers || {}
-      options.headers['x-elastic-client-meta'] = this[kMetaHeader] + ',h=s'
     }
     // TODO: study scroll search slices
     const wait = options.wait || 5000
@@ -199,7 +198,7 @@ class Helpers {
     let timeoutRef = null
     const operationsStream = new Readable({
       objectMode: true,
-      read (size) {}
+      read (size) { }
     })
 
     const p = iterate()
@@ -435,7 +434,6 @@ class Helpers {
     const { serializer } = client
     if (this[kMetaHeader] !== null) {
       reqOptions.headers = reqOptions.headers || {}
-      reqOptions.headers['x-elastic-client-meta'] = this[kMetaHeader] + ',h=bp'
     }
     const {
       datasource,

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -41,7 +41,6 @@ let clientVersion = require('../../package.json').version
 if (clientVersion.includes('-')) {
   clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
 }
-const nodeVersion = process.versions.node
 
 test('Configure host', t => {
   t.test('Single string', t => {
@@ -541,7 +540,7 @@ test('Extend client APIs', t => {
 
     const client = new Client({ node: 'http://localhost:9200' })
     try {
-      client.extend('index', () => {})
+      client.extend('index', () => { })
       t.fail('Should throw')
     } catch (err) {
       t.equal(err.message, 'The method "index" already exists')
@@ -553,7 +552,7 @@ test('Extend client APIs', t => {
 
     const client = new Client({ node: 'http://localhost:9200' })
     try {
-      client.extend('indices.delete', () => {})
+      client.extend('indices.delete', () => { })
       t.fail('Should throw')
     } catch (err) {
       t.equal(err.message, 'The method "delete" already exists on namespace "indices"')
@@ -1044,7 +1043,7 @@ test('Content length too big (buffer)', t => {
       }
       stream.on('close', () => t.pass('Stream destroyed'))
       process.nextTick(callback, null, stream)
-      return { abort () {} }
+      return { abort () { } }
     }
   }
 
@@ -1071,7 +1070,7 @@ test('Content length too big (string)', t => {
       }
       stream.on('close', () => t.pass('Stream destroyed'))
       process.nextTick(callback, null, stream)
-      return { abort () {} }
+      return { abort () { } }
     }
   }
 
@@ -1080,65 +1079,6 @@ test('Content length too big (string)', t => {
     t.ok(err instanceof errors.RequestAbortedError)
     t.equal(err.message, `The content length (${buffer.constants.MAX_STRING_LENGTH + 10}) is bigger than the maximum allowed string (${buffer.constants.MAX_STRING_LENGTH})`)
     t.equal(result.meta.attempts, 0)
-  })
-})
-
-test('Meta header enabled', t => {
-  t.plan(2)
-
-  class MockConnection extends Connection {
-    request (params, callback) {
-      t.match(params.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion}` })
-      const stream = intoStream(JSON.stringify({ hello: 'world' }))
-      stream.statusCode = 200
-      stream.headers = {
-        'content-type': 'application/json;utf=8',
-        'content-length': '17',
-        connection: 'keep-alive',
-        date: new Date().toISOString()
-      }
-      process.nextTick(callback, null, stream)
-      return { abort () {} }
-    }
-  }
-
-  const client = new Client({
-    node: 'http://localhost:9200',
-    Connection: MockConnection
-  })
-
-  client.info((err, result) => {
-    t.error(err)
-  })
-})
-
-test('Meta header disabled', t => {
-  t.plan(2)
-
-  class MockConnection extends Connection {
-    request (params, callback) {
-      t.notMatch(params.headers, { 'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion}` })
-      const stream = intoStream(JSON.stringify({ hello: 'world' }))
-      stream.statusCode = 200
-      stream.headers = {
-        'content-type': 'application/json;utf=8',
-        'content-length': '17',
-        connection: 'keep-alive',
-        date: new Date().toISOString()
-      }
-      process.nextTick(callback, null, stream)
-      return { abort () {} }
-    }
-  }
-
-  const client = new Client({
-    node: 'http://localhost:9200',
-    Connection: MockConnection,
-    enableMetaHeader: false
-  })
-
-  client.info((err, result) => {
-    t.error(err)
   })
 })
 
@@ -1156,7 +1096,7 @@ test('Prototype poisoning protection enabled by default', t => {
         date: new Date().toISOString()
       }
       process.nextTick(callback, null, stream)
-      return { abort () {} }
+      return { abort () { } }
     }
   }
 
@@ -1184,7 +1124,7 @@ test('Disable prototype poisoning protection', t => {
         date: new Date().toISOString()
       }
       process.nextTick(callback, null, stream)
-      return { abort () {} }
+      return { abort () { } }
     }
   }
 

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -41,7 +41,6 @@ let clientVersion = require('../../../package.json').version
 if (clientVersion.includes('-')) {
   clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
 }
-const nodeVersion = process.versions.node
 
 const dataset = [
   { user: 'jon', age: 23 },
@@ -57,8 +56,7 @@ test('bulk index', t => {
         onRequest (params) {
           t.equal(params.path, '/_bulk')
           t.match(params.headers, {
-            'content-type': 'application/x-ndjson',
-            'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=bp`
+            'content-type': 'application/x-ndjson'
           })
           const [action, payload] = params.body.split('\n')
           t.same(JSON.parse(action), { index: { _index: 'test' } })
@@ -102,9 +100,6 @@ test('bulk index', t => {
         onRequest (params) {
           t.equal(params.path, '/_bulk')
           t.match(params.headers, { 'content-type': 'application/x-ndjson' })
-          t.notMatch(params.headers, {
-            'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=bp`
-          })
           const [action, payload] = params.body.split('\n')
           t.same(JSON.parse(action), { index: { _index: 'test' } })
           t.same(JSON.parse(payload), dataset[count++])
@@ -1329,8 +1324,7 @@ test('Flush interval', t => {
       onRequest (params) {
         t.strictEqual(params.path, '/_bulk')
         t.match(params.headers, {
-          'content-type': 'application/x-ndjson',
-          'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=bp`
+          'content-type': 'application/x-ndjson'
         })
         const [action, payload] = params.body.split('\n')
         t.deepEqual(JSON.parse(action), { index: { _index: 'test' } })

--- a/test/unit/helpers/scroll.test.js
+++ b/test/unit/helpers/scroll.test.js
@@ -37,16 +37,11 @@ let clientVersion = require('../../../package.json').version
 if (clientVersion.includes('-')) {
   clientVersion = clientVersion.slice(0, clientVersion.indexOf('-')) + 'p'
 }
-const nodeVersion = process.versions.node
 
 test('Scroll search', async t => {
   let count = 0
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
-      t.match(params.headers, {
-        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=s`
-      })
-
       count += 1
       if (params.method === 'POST') {
         t.equal(params.querystring, 'scroll=1m')
@@ -93,9 +88,6 @@ test('Clear a scroll search', async t => {
   let count = 0
   const MockConnection = connection.buildMockConnection({
     onRequest (params) {
-      t.notMatch(params.headers, {
-        'x-elastic-client-meta': `es=${clientVersion},js=${nodeVersion},t=${clientVersion},hc=${nodeVersion},h=s`
-      })
       if (params.method === 'DELETE') {
         const body = JSON.parse(params.body)
         t.equal(body.scroll_id, 'id')


### PR DESCRIPTION
Signed-off-by: Bishoy Boktor <boktorbb@amazon.com>

### Description
Removes the elastic only x-elastic-client-meta header that is used for their telemetry purposes
 
### Issues Resolved
#122 
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).