### PR TITLE
Update cluster to use opendistro

### DIFF
--- a/.ci/opendistro/Dockerfile.opendistro
+++ b/.ci/opendistro/Dockerfile.opendistro
@@ -5,6 +5,3 @@ ARG es_path=/usr/share/elasticsearch
 
 ARG SECURE_INTEGRATION
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $es_path/bin/elasticsearch-plugin remove opendistro_security; fi
-
-
-COPY --chown=elasticsearch:elasticsearch elasticsearch-run.sh $es_path/

--- a/.ci/opendistro/docker-compose.yml
+++ b/.ci/opendistro/docker-compose.yml
@@ -9,7 +9,9 @@ services:
       args:
         - SECURE_INTEGRATION=${SECURE_INTEGRATION:-false}
         - OPENDISTRO_VERSION=${OPENDISTRO_VERSION:-latest}
-    command: /usr/share/elasticsearch/elasticsearch-run.sh
+    environment:
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
     ports:
       - "9200:9200"
     user: elasticsearch

--- a/.ci/opendistro/elasticsearch-run.sh
+++ b/.ci/opendistro/elasticsearch-run.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
- 
-set -ex
-
-/usr/share/elasticsearch/bin/elasticsearch -Ediscovery.type=single-node

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -89,7 +89,7 @@ jobs:
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
 
-    - name: Runs Elasticsearch
+    - name: Runs OpenDistro
       run: |
         make cluster.clean cluster.opendistro.build cluster.opendistro.start
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ jspm_packages
 
 package-lock.json
 
+# elasticsearch repo or binary files
+elasticsearch*
+
 test/benchmarks/macro/fixtures/*
 
 *-junit.xml


### PR DESCRIPTION
### Description
Replace helpers-integration-test and bundler-support docker created by
elastic/elastic-github-actions/elasticsearch@master with
amazon/opendistro-for-elasticsearch:latest docker image.

### Issue Resolved:
https://github.com/opensearch-project/opensearch-js/issues/133

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Test 
<img width="346" alt="Screen Shot 2021-08-16 at 2 40 06 PM" src="https://user-images.githubusercontent.com/79961084/129632935-8ff64027-a5c8-46b4-84a4-11791e5fdd96.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).