### PR TITLE
support nodejs v10

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         cluster: ["opendistro", "opensearch"]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         cluster: ["opendistro", "opensearch"]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,6 @@ jspm_packages
 #Jetbrains editor folder
 .idea
 
-package-lock.json
-
 # opensearch repo or binary files
 opensearch*
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "url": "https://github.com/opensearch-project/opensearch-js/issues"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=10"
   },
   "tsd": {
     "directory": "test/types"

--- a/test/bundlers/parcel-test/package.json
+++ b/test/bundlers/parcel-test/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": ">=12"
+    "node": ">=10"
   },
   "devDependencies": {
     "parcel": "^2.0.0-beta.1"


### PR DESCRIPTION
Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Description
Currently dashboards is running on nodejs v10. This PR add support for nodejs v10.
 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).