### PR TITLE
modify Dockerfile to solve osd connection issue

### DIFF
--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -5,4 +5,4 @@ ARG opensearch_path=/usr/share/opensearch
 ARG opensearch_yml=$opensearch_path/config/opensearch.yml
 
 ARG SECURE_INTEGRATION
-RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then echo "plugins.security.disabled: true" >> $opensearch_yml; fi
+RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearch-plugin remove opensearch-security; fi


### PR DESCRIPTION
osd without security test fail due to connection issue.
plugins.security.disabled set to true doesn't help to disable
security and osd can't connect. In this PR, I change the setting
to remove security.

### Issue Resolved:
https://github.com/opensearch-project/opensearch-js/issues/19

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Github action test:
<img width="931" alt="Screen Shot 2021-11-18 at 1 01 48 PM" src="https://user-images.githubusercontent.com/79961084/142496269-7f9c70c4-331e-4b4c-8ea8-e7d4543c9786.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 
