### PR TITLE
[Circuit-Breaker] Add memory threshold in opensearch-js client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,6 +126,10 @@ interface ClientOptions {
     password?: string;
   };
   disablePrototypePoisoningProtection?: boolean | 'proto' | 'constructor';
+  memoryCircuitBreaker?: {
+    enabled: boolean;
+    maxPercentage: number;
+  }
 }
 
 declare class Client {

--- a/index.js
+++ b/index.js
@@ -178,7 +178,8 @@ class Client extends OpenSearchAPI {
       generateRequestId: options.generateRequestId,
       name: options.name,
       opaqueIdPrefix: options.opaqueIdPrefix,
-      context: options.context
+      context: options.context,
+      memoryCircuitBreaker: options.memoryCircuitBreaker
     })
 
     this.helpers = new Helpers({

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -51,6 +51,7 @@ const clientVersion = require('../package.json').version
 const userAgent = `opensearch-js/${clientVersion} (${os.platform()} ${os.release()}-${os.arch()}; Node.js ${process.version})`
 const MAX_BUFFER_LENGTH = buffer.constants.MAX_LENGTH
 const MAX_STRING_LENGTH = buffer.constants.MAX_STRING_LENGTH
+const HEAP_SIZE_LIMIT = require('v8').getHeapStatistics().heap_size_limit
 const kCompatibleCheck = Symbol('compatible check')
 const kApiVersioning = Symbol('api versioning')
 
@@ -81,6 +82,7 @@ class Transport {
     this.opaqueIdPrefix = opts.opaqueIdPrefix
     this[kCompatibleCheck] = 0 // 0 = to be checked, 1 = checking, 2 = checked-ok, 3 checked-notok
     this[kApiVersioning] = process.env.OPENSEARCH_CLIENT_APIVERSIONING === 'true'
+    this.memoryCircuitBreaker = opts.memoryCircuitBreaker
 
     this.nodeFilter = opts.nodeFilter || defaultNodeFilter
     if (typeof opts.nodeSelector === 'function') {
@@ -247,10 +249,10 @@ class Transport {
 
       const contentEncoding = (result.headers['content-encoding'] || '').toLowerCase()
       const isCompressed = contentEncoding.indexOf('gzip') > -1 || contentEncoding.indexOf('deflate') > -1
-
       /* istanbul ignore else */
       if (result.headers['content-length'] !== undefined) {
         const contentLength = Number(result.headers['content-length'])
+        // nodeJS data type limit check
         if (isCompressed && contentLength > MAX_BUFFER_LENGTH) {
           response.destroy()
           return onConnectionError(
@@ -260,6 +262,12 @@ class Transport {
           response.destroy()
           return onConnectionError(
             new RequestAbortedError(`The content length (${contentLength}) is bigger than the maximum allowed string (${MAX_STRING_LENGTH})`, result)
+          )
+        } else if (shouldApplyCircuitBreaker(contentLength)) {
+          // Abort this response to avoid OOM crash of dashboards.
+          response.destroy()
+          return onConnectionError(
+            new RequestAbortedError(`The content length (${contentLength}) is bigger than the maximum allowed heap memory limit.`, result)
           )
         }
       }
@@ -300,6 +308,13 @@ class Transport {
       response.on('error', onEnd)
       response.on('end', onEnd)
       response.on('aborted', onAbort)
+    }
+    // Helper function to check if memory circuit breaker enabled and the response payload is too large to fit into available heap memory.
+    const shouldApplyCircuitBreaker = (contentLength) => {
+      if (!this.memoryCircuitBreaker || !this.memoryCircuitBreaker.enabled) return false
+      const maxPercentage = validateMemoryPercentage(this.memoryCircuitBreaker.maxPercentage)
+      const heapUsed = process.memoryUsage().heapUsed
+      return contentLength + heapUsed > HEAP_SIZE_LIMIT * maxPercentage
     }
 
     const onBody = (err, payload) => {
@@ -634,6 +649,11 @@ function lowerCaseHeaders (oldHeaders) {
     newHeaders[header.toLowerCase()] = oldHeaders[header]
   }
   return newHeaders
+}
+
+function validateMemoryPercentage (percentage) {
+  if (percentage < 0 || percentage > 1) return 1.0
+  return percentage
 }
 
 module.exports = Transport

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "./": "./"
   },
   "homepage": "https://www.opensearch.org/",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "versionCanary": "7.10.0-canary.6",
   "keywords": [
     "opensearch",


### PR DESCRIPTION
Signed-off-by: Zuocheng Ding <zding817@gmail.com>

### Description
This is to add memory checker to avoid dashboard out of memory crash.
There will be one field introduced in `ClientOptions`:  `memoryCircuitBreaker`. 
The default value of `memoryCircuitBreaker.enabled` is false until customer add manual config to modify it.
The default value of `memoryCircuitBreaker.maxPercentage` is `1.0` until customer modify it. The proper values should be within [0, 1] inclusively. 

 
### Issues Resolved
https://github.com/opensearch-project/opensearch-js/issues/202
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).