### PR TITLE
[FEATURE] Support for script operations in the update action of the client.helpers.bulk method

### DIFF
--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -82,6 +82,18 @@ interface UpdateActionOperation {
   }
 }
 
+interface UpdateActionDocOperation {
+  doc: {
+    [key: string]: any
+  }
+}
+
+interface UpdateActionScriptOperation {
+  script: {
+    [key: string]: any
+  }
+}
+
 interface DeleteAction {
   delete: {
     _index: string
@@ -89,7 +101,10 @@ interface DeleteAction {
   }
 }
 
-type UpdateAction = [UpdateActionOperation, Record<string, any>]
+type UpdateAction = [
+  UpdateActionOperation,
+  UpdateActionDocOperation | UpdateActionScriptOperation
+];
 type Action = IndexAction | CreateAction | UpdateAction | DeleteAction
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -524,9 +524,7 @@ class Helpers {
           bulkBody.push(actionBody, payloadBody)
         } else if (operation === 'update') {
           actionBody = serializer.serialize(action[0])
-          payloadBody = typeof chunk === 'string'
-            ? `{"doc":${chunk}}`
-            : serializer.serialize({ doc: chunk, ...action[1] })
+          payloadBody = serializer.serialize(action[1] || chunk)
           chunkBytes += Buffer.byteLength(actionBody) + Buffer.byteLength(payloadBody)
           bulkBody.push(actionBody, payloadBody)
         } else if (operation === 'delete') {

--- a/test/types/helpers.test-d.ts
+++ b/test/types/helpers.test-d.ts
@@ -36,7 +36,8 @@ import {
   BulkHelperOptions,
   ScrollSearchResponse,
   OnDropDocument,
-  MsearchHelper
+  MsearchHelper,
+  UpdateActionDocOperation
 } from '../../lib/Helpers'
 import { ApiResponse, ApiError, Context } from '../../lib/Transport'
 
@@ -108,7 +109,7 @@ expectError(
   const options: BulkHelperOptions<Record<string, any>> = {
     datasource: [],
     onDocument(doc: Record<string, any>) {
-      return [{ update: { _index: 'test' } }, doc]
+      return [{ update: { _index: 'test' } }, doc as UpdateActionDocOperation]
     }
   }
   expectAssignable<BulkHelperOptions<Record<string, any>>>(options)

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -848,12 +848,14 @@ test('bulk update', t => {
       flushBytes: 1,
       concurrency: 1,
       onDocument (doc) {
+        const currentId = id++
         return [{
           update: {
             _index: 'test',
-            _id: id++
+            _id: currentId
           }
         }, {
+          doc: dataset[currentId],
           doc_as_upsert: true
         }]
       },
@@ -896,12 +898,13 @@ test('bulk update', t => {
       flushBytes: 1,
       concurrency: 1,
       onDocument (doc) {
+        const currentId = id++
         return [{
           update: {
             _index: 'test',
-            _id: id++
+            _id: currentId
           }
-        }]
+        }, { doc: dataset[currentId] }]
       },
       onDrop (doc) {
         t.fail('This should never be called')
@@ -942,12 +945,14 @@ test('bulk update', t => {
       flushBytes: 1,
       concurrency: 1,
       onDocument (doc) {
+        const currentId = id++
         return [{
           update: {
             _index: 'test',
-            _id: id++
+            _id: currentId
           }
         }, {
+          doc: dataset[currentId],
           doc_as_upsert: true
         }]
       },


### PR DESCRIPTION
Signed-off-by: huuyafwww [huuya1234fwww@gmail.com](mailto:huuya1234fwww@gmail.com)

### Description
This is a modification to the client.helpers.bulk method to support script operations in the update action.
 
### Issues Resolved
#209
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).