### PR TITLE
[BUG] Fixed type definition of onDrop in helper.bulk

### DIFF
--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -114,7 +114,8 @@ export interface OnDropDocument<TDocument = unknown> {
       type: string,
       reason: string
     }
-  }
+  },
+  operation: TDocument
   document: TDocument
   retried: boolean
 }

--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -115,7 +115,7 @@ export interface OnDropDocument<TDocument = unknown> {
       reason: string
     }
   }
-  operation: TDocument
+  operation: Action
   document: TDocument
   retried: boolean
 }

--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -114,7 +114,7 @@ export interface OnDropDocument<TDocument = unknown> {
       type: string,
       reason: string
     }
-  },
+  }
   operation: TDocument
   document: TDocument
   retried: boolean


### PR DESCRIPTION
Signed-off-by: huuyafwww <huuya1234fwww@gmail.com>

### Description
Added "operation" to the type definition of onDrop in helper.bulk because it was missing.
 
### Issues Resolved
#211
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).