### PR TITLE
Add support to test against multiple versions of OpenSearch

### DIFF
--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -1,5 +1,5 @@
 ARG OPENSEARCH_VERSION
-FROM opensearchproject/opensearch:$OPENSEARCH_VERSION
+FROM opensearchproject/opensearch:${OPENSEARCH_VERSION}
 
 ARG opensearch_path=/usr/share/opensearch
 ARG opensearch_yml=$opensearch_path/config/opensearch.yml

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -8,23 +8,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        secured: ["true", "false"]
         entry:
-          - { version: '1.1.0', secured: 'true' }
-          - { version: '1.1.0', secured: 'false' }
-          - { version: '1.2.0', secured: 'true' }
-          - { version: '1.2.0', secured: 'false' }
-          - { version: '1.2.1', secured: 'true' }
-          - { version: '1.2.1', secured: 'false' }
-          - { version: '1.2.2', secured: 'true' }
-          - { version: '1.2.2', secured: 'false' }
-          - { version: '1.2.3', secured: 'true' }
-          - { version: '1.2.3', secured: 'false' }
-          - { version: '1.2.4', secured: 'true' }
-          - { version: '1.2.4', secured: 'false' }
-          - { version: '1.3.0', secured: 'true' }
-          - { version: '1.3.0', secured: 'false' }
-          - { version: '1.3.1', secured: 'true' }
-          - { version: '1.3.1', secured: 'false' }
+          - { opensearch_version: 1.1.0 }
+          - { opensearch_version: 1.2.0 }
+          - { opensearch_version: 1.2.1 }
+          - { opensearch_version: 1.2.2 }
+          - { opensearch_version: 1.2.3 }
+          - { opensearch_version: 1.2.4 }
+          - { opensearch_version: 1.3.0 }
+          - { opensearch_version: 1.3.1 }
 
     steps:
     - uses: actions/checkout@v2
@@ -38,8 +31,8 @@ jobs:
 
     - name: Runs OpenSearch cluster
       run: |
-        export OPENSEARCH_VERSION=${{ matrix.entry.version }}
-        export SECURE_INTEGRATION=${{ matrix.entry.secured }}
+        export OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
+        export SECURE_INTEGRATION=${{ matrix.secured }}
         make cluster.clean cluster.opensearch.build cluster.opensearch.start
 
     - name: Use Node.js 16.x
@@ -52,12 +45,12 @@ jobs:
         npm install
 
     - name: Integration test without security
-      if: ${{ matrix.entry.secured == 'false'}}
+      if: ${{ matrix.secured == 'false'}}
       run: |
         npm run test:integration:helpers
     
     - name: Integration test with security
-      if: ${{ matrix.entry.secured == 'true'}}
+      if: ${{ matrix.secured == 'true'}}
       run: |
         npm run test:integration:helpers-secure
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,66 @@
+name: Integration for Compatibility
+
+on: [push, pull_request]
+
+jobs:
+  integration-test-compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        entry:
+          - { version: '1.1.0', secured: 'true' }
+          - { version: '1.1.0', secured: 'false' }
+          - { version: '1.2.0', secured: 'true' }
+          - { version: '1.2.0', secured: 'false' }
+          - { version: '1.2.1', secured: 'true' }
+          - { version: '1.2.1', secured: 'false' }
+          - { version: '1.2.2', secured: 'true' }
+          - { version: '1.2.2', secured: 'false' }
+          - { version: '1.2.3', secured: 'true' }
+          - { version: '1.2.3', secured: 'false' }
+          - { version: '1.2.4', secured: 'true' }
+          - { version: '1.2.4', secured: 'false' }
+          - { version: '1.3.0', secured: 'true' }
+          - { version: '1.3.0', secured: 'false' }
+          - { version: '1.3.1', secured: 'true' }
+          - { version: '1.3.1', secured: 'false' }
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure sysctl limits
+      run: |
+        sudo swapoff -a
+        sudo sysctl -w vm.swappiness=1
+        sudo sysctl -w fs.file-max=262144
+        sudo sysctl -w vm.max_map_count=262144
+
+    - name: Runs OpenSearch cluster
+      run: |
+        export OPENSEARCH_VERSION=${{ matrix.entry.version }}
+        export SECURE_INTEGRATION=${{ matrix.entry.secured }}
+        make cluster.clean cluster.opensearch.build cluster.opensearch.start
+
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+
+    - name: Install
+      run: |
+        npm install
+
+    - name: Integration test without security
+      if: ${{ matrix.entry.secured == 'false'}}
+      run: |
+        npm run test:integration:helpers
+    
+    - name: Integration test with security
+      if: ${{ matrix.entry.secured == 'true'}}
+      run: |
+        npm run test:integration:helpers-secure
+
+    - name: Stop the OpenSearch cluster
+      run: |
+        make cluster.opensearch.stop

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,18 @@
+- [Compatibility with OpenSearch](#compatibility-with-opensearch)
+
+## Compatibility with OpenSearch
+
+The below matrix shows the compatibility of the [`opensearch-js`](https://www.npmjs.com/package/@opensearch-project/opensearch) with versions of [`OpenSearch`](https://opensearch.org/downloads.html#opensearch).
+
+| OpenSearch Version | Client Version |
+| --- | --- |
+| 1.0.0 | 1.0.0 |
+| 1.0.1 | 1.0.0 |
+| 1.1.0 | 1.1.0 |
+| 1.2.0 | 1.1.0 |
+| 1.2.1 | 1.1.0 |
+| 1.2.2 | 1.1.0 |
+| 1.2.3 | 1.1.0 |
+| 1.2.4 | 1.1.0 |
+| 1.3.0 | 1.1.0 |
+| 1.3.1 | 1.1.0 |


### PR DESCRIPTION
### Description
Adding support to run tests against multiple versions of OpenSearch in the CI. I separated out the `compatibility.yml` since the matrix was becoming huge in the `integration.yml` with multiple node js versions.
 
### Issues Resolved
#214 
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).