### PR TITLE
add 2.0.0 in integration compatibility

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -18,6 +18,7 @@ jobs:
           - { opensearch_version: 1.2.4 }
           - { opensearch_version: 1.3.0 }
           - { opensearch_version: 1.3.1 }
+          - { opensearch_version: 2.0.0 }
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
integration fail on 2.0.0 test which are expected since 2.0.0 is not officially published.



### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
