### PR TITLE
Allow document to be overwritten in `onDocument` iteratee of bulk helper

### DIFF
--- a/lib/Helpers.d.ts
+++ b/lib/Helpers.d.ts
@@ -82,14 +82,14 @@ export interface BulkStats {
   aborted: boolean;
 }
 
-interface IndexAction {
+interface IndexActionOperation {
   index: {
     _index: string;
     [key: string]: any;
   };
 }
 
-interface CreateAction {
+interface CreateActionOperation {
   create: {
     _index: string;
     [key: string]: any;
@@ -110,6 +110,8 @@ interface DeleteAction {
   };
 }
 
+type CreateAction = CreateActionOperation | [CreateActionOperation, unknown];
+type IndexAction = IndexActionOperation | [IndexActionOperation, unknown];
 type UpdateAction = [UpdateActionOperation, Record<string, any>];
 type Action = IndexAction | CreateAction | UpdateAction | DeleteAction;
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -532,21 +532,20 @@ class Helpers {
       for await (const chunk of datasource) {
         if (shouldAbort === true) break;
         timeoutRef.refresh();
-        const action = onDocument(chunk);
-        const operation = Array.isArray(action)
-          ? Object.keys(action[0])[0]
-          : Object.keys(action)[0];
+        const result = onDocument(chunk);
+        const [action, payload] = Array.isArray(result) ? result : [result, chunk];
+        const operation = Object.keys(action)[0];
         if (operation === 'index' || operation === 'create') {
           actionBody = serializer.serialize(action);
-          payloadBody = typeof chunk === 'string' ? chunk : serializer.serialize(chunk);
+          payloadBody = typeof payload === 'string' ? payload : serializer.serialize(payload);
           chunkBytes += Buffer.byteLength(actionBody) + Buffer.byteLength(payloadBody);
           bulkBody.push(actionBody, payloadBody);
         } else if (operation === 'update') {
-          actionBody = serializer.serialize(action[0]);
+          actionBody = serializer.serialize(action);
           payloadBody =
             typeof chunk === 'string'
               ? `{"doc":${chunk}}`
-              : serializer.serialize({ doc: chunk, ...action[1] });
+              : serializer.serialize({ doc: chunk, ...payload });
           chunkBytes += Buffer.byteLength(actionBody) + Buffer.byteLength(payloadBody);
           bulkBody.push(actionBody, payloadBody);
         } else if (operation === 'delete') {


### PR DESCRIPTION
### Description

Allows the document to be submitted to be altered in the `onDocument` iteratee of the `bulk` method of the Elasticsearch Client Helpers.

Corresponsing PR in `elastic/elasticsearch-js`, which this package forks: https://github.com/elastic/elasticsearch-js/pull/1732

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
