### PR TITLE
Add missing memory circuit breaker options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ import Transport, {
   RequestBody,
   RequestNDBody,
   Context,
+  MemoryCircuitBreakerOptions,
 } from './lib/Transport';
 import { URL } from 'url';
 import Connection, { AgentOptions, agentFn } from './lib/Connection';
@@ -137,10 +138,7 @@ interface ClientOptions {
     password?: string;
   };
   disablePrototypePoisoningProtection?: boolean | 'proto' | 'constructor';
-  memoryCircuitBreaker?: {
-    enabled: boolean;
-    maxPercentage: number;
-  };
+  memoryCircuitBreaker?: MemoryCircuitBreakerOptions
 }
 
 declare class Client {

--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -29,10 +29,10 @@
  */
 
 import { Readable as ReadableStream } from 'stream';
-import { ConnectionPool, CloudConnectionPool } from './pool';
 import Connection from './Connection';
-import Serializer from './Serializer';
 import * as errors from './errors';
+import { CloudConnectionPool, ConnectionPool } from './pool';
+import Serializer from './Serializer';
 
 export type ApiError =
   | errors.ConfigurationError
@@ -59,6 +59,11 @@ export interface generateRequestIdFn {
   (params: TransportRequestParams, options: TransportRequestOptions): any;
 }
 
+export interface MemoryCircuitBreakerOptions {
+  enabled: boolean;
+  maxPercentage: number;
+}
+
 interface TransportOptions {
   emit: (event: string | symbol, ...args: any[]) => boolean;
   connectionPool: ConnectionPool | CloudConnectionPool;
@@ -77,6 +82,7 @@ interface TransportOptions {
   generateRequestId?: generateRequestIdFn;
   name?: string;
   opaqueIdPrefix?: string;
+  memoryCircuitBreaker?: MemoryCircuitBreakerOptions;
 }
 
 export interface RequestEvent<TResponse = Record<string, any>, TContext = Context> {
@@ -172,6 +178,7 @@ export default class Transport {
   sniffInterval: number;
   sniffOnConnectionFault: boolean;
   opaqueIdPrefix: string | null;
+  memoryCircuitBreaker: MemoryCircuitBreakerOptions | undefined;
   sniffEndpoint: string;
   _sniffEnabled: boolean;
   _nextSniff: number;


### PR DESCRIPTION
### Description
Add missing `memoryCircuitBreaker` option in `Transport.d.ts`.

The discussion in https://github.com/opensearch-project/documentation-website/issues/823 revealed that this option appeared to be missing: https://github.com/opensearch-project/documentation-website/issues/823#issuecomment-1191962709

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
