### PR TITLE
issue #291 initialize request.headers by value, not reference

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -218,7 +218,7 @@ class Connection {
       origin: url.origin,
       // https://github.com/elastic/elasticsearch-js/issues/843
       port: url.port !== '' ? url.port : undefined,
-      headers: this.headers,
+      headers: Object.assign({}, this.headers), // issue #291 initialize by value, not reference
       agent: this.agent,
     };
 


### PR DESCRIPTION
### Description
This modifies how request.headers are initialized. Instead of initializing request.headers by reference to Connection.headers, this makes a copy of Connection.headers. This way, any changes to request.headers are not reflected in the underlying connection, which is reused for multiple requests.

### Issues Resolved
https://github.com/opensearch-project/opensearch-js/issues/291

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
