### PR TITLE
Retry for OpenSearch Container

### DIFF
--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -5,4 +5,10 @@ ARG opensearch_path=/usr/share/opensearch
 ARG opensearch_yml=$opensearch_path/config/opensearch.yml
 
 ARG SECURE_INTEGRATION
+
+HEALTHCHECK --start-period=20s --interval=5s --retries=2 --timeout=1s \
+  CMD if [ "$SECURE_INTEGRATION" != "true" ]; \
+  then curl --fail localhost:9200/_cat/health; \
+  else curl --fail -k https:/localhost:9200/_cat/health -u admin:admin; fi
+
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearch-plugin remove opensearch-security; fi

--- a/.ci/opensearch/docker-compose.yml
+++ b/.ci/opensearch/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   opensearch:
+    restart: always
     build:
       context: .
       dockerfile: Dockerfile.opensearch
@@ -11,6 +12,17 @@ services:
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
+      - SECURE_INTEGRATION=${SECURE_INTEGRATION:-false}
     ports:
       - '9200:9200'
     user: opensearch
+  autoheal:
+    restart: always
+    image: willfarrell/autoheal
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=all
+      - AUTOHEAL_START_PERIOD=30
+      - AUTOHEAL_INTERVAL=5
+      - AUTOHEAL_DEFAULT_STOP_TIMEOUT=30
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -34,6 +34,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
 
       - name: Runs OpenSearch cluster
+        id: start_opensearch_cluster
         run: |
           export OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
           export SECURE_INTEGRATION=${{ matrix.secured }}
@@ -59,5 +60,6 @@ jobs:
           npm run test:integration:helpers-secure
 
       - name: Stop the OpenSearch cluster
+        if: ${{ steps.start_opensearch_cluster.outcome == 'success'}}
         run: |
           make cluster.opensearch.stop

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ cluster.opensearch.build:
 
 cluster.opensearch.start:
 	docker-compose --project-directory .ci/opensearch up -d ;
-	sleep 20;
+	sleep 60;
 
 cluster.opensearch.stop:
 	docker-compose --project-directory .ci/opensearch down ;


### PR DESCRIPTION
### Description
Tests that run `docker-compose up` randomly fail with "no tests found error". Rerunning the failed jobs resolves the issue. This is [a bug in Opensearch build](https://github.com/opensearch-project/opensearch-build/issues/2568) that causes the container to intermittently fail. Restarting the container when encountering this issue is a workaround this PR is addressing.

### Issues Resolved

closes https://github.com/opensearch-project/opensearch-js/issues/268

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
