### PR TITLE
Add release workflows

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Draft a release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Github workflow for changelog verification ([#306](https://github.com/opensearch-project/opensearch-js/pull/306))
+- Add GitHub and Jenkins release workflow ([#317](https://github.com/opensearch-project/opensearch-js/pull/317))
 ### Dependencies
 - Bumps `tsd` from 0.22.0 to 0.24.1
 

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.0.5', retriever: modernSCM([
+lib = library(identifier: 'jenkins@1.1.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -4,7 +4,7 @@ lib = library(identifier: 'jenkins@1.0.5', retriever: modernSCM([
 ]))
 
 standardReleasePipelineWithGenericTrigger(
-    tokenIdCredential: 'opensearch-js-webhook-token',
+    tokenIdCredential: 'jenkins-opensearch-js-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-js repository causing this workflow to run',
     publishRelease: true){
         publishToNpm(repository: 'https://github.com/opensearch-project/opensearch-js', tag: "$tag")

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,0 +1,11 @@
+lib = library(identifier: 'jenkins@1.0.5', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    tokenIdCredential: 'opensearch-js-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/opensearch-js repository causing this workflow to run',
+    publishRelease: true){
+        publishToNpm(repository: 'https://github.com/opensearch-project/opensearch-js', tag: "$tag")
+    }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
This change automates the release of opensearch-js on npmjs platform. Please see https://github.com/opensearch-project/opensearch-build/issues/1234 for more details on how the end to end workflow is expected to work.

TL;DR:
When a tag is pushed to this repository, it will generate a draft release. The draft release will trigger the jenkins job (see `Files Changed` for attached jenkins file) that publishes the client to npmjs. Once the release is successful, the drafted release is published on GitHub.


### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2690

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
