### PR TITLE
Add release details and bump the jenkins lib version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Github workflow for changelog verification ([#306](https://github.com/opensearch-project/opensearch-js/pull/306))
 - Add GitHub and Jenkins release workflow ([#317](https://github.com/opensearch-project/opensearch-js/pull/317))
+- Add release details to releasing.md ([319](https://github.com/opensearch-project/opensearch-js/pull/319))
 ### Dependencies
 - Bumps `tsd` from 0.22.0 to 0.24.1
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,4 +31,5 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 ## Releasing
 
-The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
+The release process includes a [maintainer](MAINTAINERS.md) pushing a tag to this repository. This creates a draft release which then triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-js-release/) and releases the client on [npmjs](https://www.npmjs.com/package/@opensearch-project/opensearch).
+See the GitHub [issue](https://github.com/opensearch-project/opensearch-build/issues/1234) for more details on end to end release workflow.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,5 +31,10 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 ## Releasing
 
-The release process includes a [maintainer](MAINTAINERS.md) pushing a tag to this repository. This creates a draft release which then triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-js-release/) and releases the client on [npmjs](https://www.npmjs.com/package/@opensearch-project/opensearch).
-See the GitHub [issue](https://github.com/opensearch-project/opensearch-build/issues/1234) for more details on end to end release workflow.
+The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
+
+1. Create a tag, e.g. v2.1.0, and push it to the GitHub repo.
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
+1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-js-release/) as a result of which opensearch-js client is released on [npmjs](https://www.npmjs.com/package/@opensearch-project/opensearch).
+1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. Increment "version" in package.json to the next patch release, e.g. v2.1.1. See [example](https://github.com/opensearch-project/opensearch-js/pull/318)

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.1.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@1.1.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -6,6 +6,6 @@ lib = library(identifier: 'jenkins@1.1.0', retriever: modernSCM([
 standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-opensearch-js-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-js repository causing this workflow to run',
-    publishRelease: true){
+    publishRelease: true) {
         publishToNpm(repository: 'https://github.com/opensearch-project/opensearch-js', tag: "$tag")
     }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Adds release details to releasing.md.
Also bumps the jenkins lib version to 1.1.1 that includes a fix to publish the release on Github.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
