### PR TITLE
Implement JSDOC

### DIFF
--- a/.ci/license/check-license-headers.sh
+++ b/.ci/license/check-license-headers.sh
@@ -37,13 +37,13 @@ function check_license_header {
 cd "$TOP"
 nErrors=0
 
-for f in $(git ls-files --directory ../ | grep '\.ts$'); do
+for f in $(git ls-files --directory ../ | grep '\.ts$' | grep -v '^docs/'); do
     if ! check_license_header $f; then
         nErrors=$((nErrors+1))
     fi
 done
 
-for f in $(git ls-files --directory ../ | grep '\.js$'); do
+for f in $(git ls-files --directory ../ | grep '\.js$' | grep -v '^docs/'); do
     if ! check_license_header $f; then
         nErrors=$((nErrors+1))
     fi

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,0 +1,37 @@
+name: Publish Docs to Github Pages
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, jsdoc]
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    name: Update gh-pages with docs
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v1
+        with:
+          ruby-version: 16.x
+      - name: Install Tools
+        run: |
+          sudo apt install -y jq
+          npm install -g jsdoc
+      - name: Generate Docs
+        run: |
+          export PACKAGE_VERSION=$(jq .version package.json -r | awk -F. '{print $1"."$2}')
+          export DOC_FOLDER=docs/$PACKAGE_VERSION 
+          jsdoc api lib -d $DOC_FOLDER -r --readme README.md
+          cp *.md $DOC_FOLDER
+          cp *.txt $DOC_FOLDER
+      - name: Commit Docs Change
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          add: 'docs/* -f'
+      - name: Deploy Docs to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          keep_files: true
+          enable_jekyll: true

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ opensearch*
 !opensearch_dashboards*
 !opensearchDashboards*
 
+# documentation
+docs/
+
 test/benchmarks/macro/fixtures/*
 
 *-junit.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Add release details to releasing.md ([319](https://github.com/opensearch-project/opensearch-js/pull/319))
 - Allow overriding the aws service identifier in AwsSigv4Signer ([333](https://github.com/opensearch-project/opensearch-js/pull/333))
+- Added jsdoc for documentation generation ([#335](https://github.com/opensearch-project/opensearch-js/issues/335))
+- Documented Transport#request ([#335](https://github.com/opensearch-project/opensearch-js/issues/335))
+- Documented all API methods ([#335](https://github.com/opensearch-project/opensearch-js/issues/335))
 ### Dependencies
 ### Changed
 ### Deprecated

--- a/api/api/bulk.js
+++ b/api/api/bulk.js
@@ -63,6 +63,29 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * The bulk operation lets you add, update, or delete many documents in a single request.
+ * Compared to individual OpenSearch indexing requests, the bulk operation has significant performance benefits.
+ * Whenever practical, we recommend batching indexing operations into bulk requests.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/document-apis/bulk/|OpenSearch - Bulk}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {Object[]} params.body - {@link https://opensearch.org/docs/latest/api-reference/document-apis/bulk/#request-body|Request Body}
+ * @param {string} [params.index] - Specifying the index means you don’t need to include it in the request body.
+ * @param {string} [params.pipeline] - The pipeline ID for preprocessing documents.
+ * @param {string} [params.routing] - Routes the request to the specified shard.
+ * @param {string} [params.refresh=false] - If true, OpenSearch refreshes shards to make the operation visible to searching. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.timeout=1m] - How long to wait for a response from the cluster.
+ * @param {string} [params.wait_for_active_shards] - The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
+ * @param {boolean} [params.require_alias=false] - Specifies whether the target index must be an index alias.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/document-apis/bulk/#response|Bulk Response}
+ */
 function bulkApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/cat.js
+++ b/api/api/cat.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-CAT */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'format',
@@ -69,6 +71,7 @@ const acceptedQuerystring = [
   'nodes',
   'actions',
   'parent_task_id',
+  'pri',
 ];
 const snakeCase = {
   expandWildcards: 'expand_wildcards',
@@ -92,6 +95,22 @@ function CatApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+/**
+ * The CAT aliases operation lists the mapping of aliases to indices, plus routing and filtering information.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/ OpenSearch - CAT aliases}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.name] - To limit the information to specific aliases, provide the alias names seperated by commas.
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster manager node.
+ * @param {string} [params.expand_wildcards=open] - Expands wildcard expressions to concrete indices. Combine multiple values with commas. Supported values are 'all', 'open', 'closed', 'hidden', and 'none'. Default is 'open'.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/#response CAT aliases Response}
+ */
 CatApi.prototype.aliases = function catAliasesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -118,6 +137,23 @@ CatApi.prototype.aliases = function catAliasesApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT allocation operation lists the allocation of disk space for indices and the number of shards on each node.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/ OpenSearch - CAT allocation}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.node_id] - To limit the information to specific nodes, provide the node names seperated by commas.
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {string} [params.bytes] - Specify the units for byte size. For example, '7kb' or '6gb'.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-allocation/#response CAT allocation Response}
+ */
 CatApi.prototype.allocation = function catAllocationApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -144,6 +180,20 @@ CatApi.prototype.allocation = function catAllocationApi(params, options, callbac
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT count operation lists the number of documents in your cluster.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-count/ OpenSearch - CAT count}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.index] - To see the number of documents in specific indices or aliases, provide the index/alias names seperated by commas.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-count/#response CAT count Response}
+ */
 CatApi.prototype.count = function catCountApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -170,6 +220,20 @@ CatApi.prototype.count = function catCountApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT fielddata operation lists the memory size used by each field per node.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/ OpenSearch - CAT fielddata}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.fields] - To limit the information to specific fields, provide the field names seperated by commas.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-field-data/#response CAT fielddata Response}
+ */
 CatApi.prototype.fielddata = function catFielddataApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -196,6 +260,22 @@ CatApi.prototype.fielddata = function catFielddataApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT health operation lists the status of the cluster, how long the cluster has been up, the number of nodes,
+ * and other useful information that helps you analyze the health of your cluster.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-health/ OpenSearch - CAT health}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.time] - Specify the units for time. For example, '5d' or '7h'.
+ * @param {boolean} [params.ts=true] - If true, returns HH:MM:SS and Unix epoch timestamps.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-health/#response CAT health Response}
+ */
 CatApi.prototype.health = function catHealthApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -217,6 +297,18 @@ CatApi.prototype.health = function catHealthApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * See the available operations in the CAT API
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/index OpenSearch - CAT}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - (ignored)
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 CatApi.prototype.help = function catHelpApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -238,6 +330,27 @@ CatApi.prototype.help = function catHelpApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT indices operation lists information related to indices—how much disk space they are using, how many shards they have, their health status, and so on.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-indices/ OpenSearch - CAT indices}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.index] - To limit the information to specific indices, provide the index names seperated by commas.
+ * @param {string} [params.bytes] - Specify the units for byte size. For example, '7kb' or '6gb'.
+ * @param {string} [params.health] - Limit indices based on their health status. Supported values are 'green', 'yellow', and 'red'.
+ * @param {boolean} [params.include_unloaded_segments=false] - Whether to include information from segments not loaded into memory.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {boolean} [params.pri=false] - Whether to return information only from the primary shards.
+ * @param {string} [params.time] - Specify the units for time. For example, '5d' or '7h'.
+ * @param {string} [params.expand_wildcards=open] - Expands wildcard expressions to concrete indices. Combine multiple values with commas. Supported values are 'all', 'open', 'closed', 'hidden', and 'none'.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-indices/#response CAT indices Response}
+ */
 CatApi.prototype.indices = function catIndicesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -264,6 +377,18 @@ CatApi.prototype.indices = function catIndicesApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT cluster manager operation lists information that helps identify the elected cluster manager node.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/ OpenSearch - CAT cluster manager}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters}
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-cluster_manager/#response CAT cluster manager Response}
+ */
 CatApi.prototype.cluster_manager = function catClusterManagerApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -310,6 +435,21 @@ CatApi.prototype.master = function catMasterApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT nodeattrs operation lists the attributes of custom nodes.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/ OpenSearch - CAT aliases}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/#response CAT nodeattrs Response}
+ */
 CatApi.prototype.nodeattrs = function catNodeattrsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -331,6 +471,25 @@ CatApi.prototype.nodeattrs = function catNodeattrsApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT nodes operation lists node-level information, including node roles and load metrics.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/ OpenSearch - CAT nodes}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.bytes] - Specify the units for byte size. For example, '7kb' or '6gb'.
+ * @param {boolean} [params.full_id=false] - If true, return the full node ID. If false, return the shortened node ID.
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster_manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {string} [params.time] - Specify the units for time. For example, '5d' or '7h'.
+ * @param {boolean} [params.include_unloaded_segments=false] - Whether to include information from segments not loaded into memory.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-nodes/#response CAT nodes Response}
+ */
 CatApi.prototype.nodes = function catNodesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -352,6 +511,22 @@ CatApi.prototype.nodes = function catNodesApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT pending tasks operation lists the progress of all pending tasks, including task priority and time in queue.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/ OpenSearch - CAT pending tasks}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster_manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {string} [params.time] - Specify the units for time. For example, '5d' or '7h'.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-pending-tasks/#response CAT pending tasks Response}
+ */
 CatApi.prototype.pendingTasks = function catPendingTasksApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -373,6 +548,21 @@ CatApi.prototype.pendingTasks = function catPendingTasksApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT plugins operation lists the names, components, and versions of the installed plugins.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/ OpenSearch - CAT plugins}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster_manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-plugins/#response CAT plugins Response}
+ */
 CatApi.prototype.plugins = function catPluginsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -394,6 +584,23 @@ CatApi.prototype.plugins = function catPluginsApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT recovery operation lists all completed and ongoing index and shard recoveries.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-recovery/ OpenSearch - CAT recovery}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.bytes] - Specify the units for byte size. For example, '7kb' or '6gb'.
+ * @param {string} [params.time] - Specify the units for time. For example, '5d' or '7h'.
+ * @param {boolean} [params.active_only=false] - Whether to only include ongoing shard recoveries.
+ * @param {boolean} [params.detailed=false] - Whether to only include ongoing shard recoveries.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-recovery/#response CAT recovery Response}
+ */
 CatApi.prototype.recovery = function catRecoveryApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -420,6 +627,21 @@ CatApi.prototype.recovery = function catRecoveryApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT repositories operation lists all completed and ongoing index and shard recoveries.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/ OpenSearch - CAT repositories}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster_manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-repositories/#response CAT repositories Response}
+ */
 CatApi.prototype.repositories = function catRepositoriesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -441,6 +663,22 @@ CatApi.prototype.repositories = function catRepositoriesApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The cat segments operation lists Lucene segment-level information for each index.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-segments/ OpenSearch - CAT segments}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.index] - To see only the information about segments of specific indices, provide the index names seperated by commas.
+ * @param {string} [params.bytes] - Specify the units for byte size. For example, '7kb' or '6gb'.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-segments/#response CAT segments Response}
+ */
 CatApi.prototype.segments = function catSegmentsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -467,6 +705,24 @@ CatApi.prototype.segments = function catSegmentsApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT shards operation lists the state of all primary and replica shards and how they are distributed.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-shards/ OpenSearch - CAT shards}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.index] - To see only the information about shards of specific indices, provide the index names seperated by commas.
+ * @param {string} [params.bytes] - Specify the units for byte size. For example, '7kb' or '6gb'.
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster_manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {string} [params.time] - Specify the units for time. For example, '5d' or '7h'.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-shards/#response CAT shards Response}
+ */
 CatApi.prototype.shards = function catShardsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -493,6 +749,21 @@ CatApi.prototype.shards = function catShardsApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT snapshots operation lists all snapshots for a repository.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/ OpenSearch - CAT snapshots}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {string} [params.time] - Specify the units for time. For example, '5d' or '7h'.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-snapshots/#response CAT snapshots Response}
+ */
 CatApi.prototype.snapshots = function catSnapshotsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -519,6 +790,23 @@ CatApi.prototype.snapshots = function catSnapshotsApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT tasks operation lists the progress of all tasks currently running on your cluster.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/ OpenSearch - CAT tasks}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {string} [params.nodes] - A comma-separated list of node IDs or names to limit the returned information. Use '_local' to return information from the node you’re connecting to, specify the node name to get information from specific nodes, or keep the parameter empty to get information from all nodes.
+ * @param {string} [params.time] - Specify the units for time. For example, '5d' or '7h'.
+ * @param {boolean} [params.detailed=false] - Returns detailed task information.
+ * @param {string} [params.parent_task_id] - Returns tasks with a specified parent task ID (node_id:task_number). Keep empty or set to -1 to return all.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-tasks/#response CAT tasks Response}
+ */
 CatApi.prototype.tasks = function catTasksApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -540,6 +828,22 @@ CatApi.prototype.tasks = function catTasksApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT templates operation lists the names, patterns, order numbers, and version numbers of index templates.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-templates/ OpenSearch - CAT templates}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {boolean} [params.name] - If you want to limit it to a specific template or pattern, provide the template name or pattern.
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-templates/#response CAT templates Response}
+ */
 CatApi.prototype.templates = function catTemplatesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -566,6 +870,21 @@ CatApi.prototype.templates = function catTemplatesApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The CAT thread pool operation lists the active, queued, and rejected threads of different thread pools on each node.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/ OpenSearch - CAT thread pool}
+ *
+ * @memberOf API-CAT
+ *
+ * @param {Object} params - Accepts {@link https://opensearch.org/docs/latest/api-reference/cat/index#optional-query-parameters - common CAT parameters} along with the following unique parameters:
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cat/cat-thread-pool/#response CAT thread pool Response}
+ */
 CatApi.prototype.threadPool = function catThreadPoolApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/clear_scroll.js
+++ b/api/api/clear_scroll.js
@@ -36,6 +36,20 @@ const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = 
 const acceptedQuerystring = ['pretty', 'human', 'error_trace', 'source', 'filter_path'];
 const snakeCase = { errorTrace: 'error_trace', filterPath: 'filter_path' };
 
+/**
+ * Close the search context when you’re done scrolling, because the scroll operation continues to consume computing resources until the timeout.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/scroll/ OpenSearch - Scroll }
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} [params.scroll_id] The ID of the scroll to be terminated. Use `_all` to close all open scroll contexts.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function clearScrollApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/cluster.js
+++ b/api/api/cluster.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Cluster */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'include_yes_decisions',
@@ -100,6 +102,26 @@ function ClusterApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+/**
+ * The most basic cluster allocation explain request finds an unassigned shard and explains why it can’t be allocated to a node. If you add some options, you can instead get information on a specific shard, including why OpenSearch assigned it to its current node.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cluster-allocation/ OpenSearch - Cluster allocation explain}
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {boolean} [params.include_yes_decisions=false] - OpenSearch makes a series of yes or no decisions when trying to allocate a shard to a node. If this parameter is true, OpenSearch includes the (generally more numerous) “yes” decisions in its response.
+ * @param {boolean} [params.include_disk_info=false] - Whether to include information about disk usage in the response.
+ * @param {Object} [params.body]
+ * @param {string} [params.body.current_node] - If you only want an explanation if the shard happens to be on a particular node, specify that node name here.
+ * @param {string} [params.body.index] - The name of the shard’s index.
+ * @param {boolean} [params.body.primary] - Whether to provide an explanation for the primary shard (true) or its first replica (false), which share the same shard ID.
+ * @param {number} [params.body.shard] - The shard ID that you want an explanation for.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cluster-allocation/#response Cluster allocation explain Response}
+ */
 ClusterApi.prototype.allocationExplain = function clusterAllocationExplainApi(
   params,
   options,
@@ -125,6 +147,19 @@ ClusterApi.prototype.allocationExplain = function clusterAllocationExplainApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Delete Component Template(s)
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {string} [params.name] The name of the component template to be deleted.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.deleteComponentTemplate = function clusterDeleteComponentTemplateApi(
   params,
   options,
@@ -156,6 +191,19 @@ ClusterApi.prototype.deleteComponentTemplate = function clusterDeleteComponentTe
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Clears cluster voting config exclusions.
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {boolean} [params.wait_for_removal] Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.deleteVotingConfigExclusions = function clusterDeleteVotingConfigExclusionsApi(
   params,
   options,
@@ -181,6 +229,19 @@ ClusterApi.prototype.deleteVotingConfigExclusions = function clusterDeleteVoting
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Information about whether a particular component template exist
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {boolean} [params.name] Name of the template
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.existsComponentTemplate = function clusterExistsComponentTemplateApi(
   params,
   options,
@@ -212,6 +273,19 @@ ClusterApi.prototype.existsComponentTemplate = function clusterExistsComponentTe
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns one or more component templates
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {string | string[]} [params.name] Name(s) of the template(s)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.getComponentTemplate = function clusterGetComponentTemplateApi(
   params,
   options,
@@ -242,6 +316,21 @@ ClusterApi.prototype.getComponentTemplate = function clusterGetComponentTemplate
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Get Cluster Settings
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cluster-settings/ OpenSearch - Cluster Settings}
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * ç
+ * @param {boolean} [params.include_defaults] Whether to include default settings as part of the response. This parameter is useful for identifying the names and current values of settings you want to update.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.getSettings = function clusterGetSettingsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -263,6 +352,30 @@ ClusterApi.prototype.getSettings = function clusterGetSettingsApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * The most basic cluster health request returns a simple status of the health of your cluster. OpenSearch expresses cluster health in three colors: green, yellow, and red. A green status means all primary shards and their replicas are allocated to nodes. A yellow status means all primary shards are allocated to nodes, but some replicas aren’t. A red status means at least one primary shard is not allocated to any node.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cluster-health/ OpenSearch - Cluster Health}
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {} [params.index] - To get the status of a specific index, provide the index name.
+ * @param {string} [params.expand_wildcards=open] - Expands wildcard expressions to concrete indices. Combine multiple values with commas. Supported values are 'all', 'open', 'closed', 'hidden', and 'none'.
+ * @param {string} [params.level=cluster] - The level of detail for returned health information. Supported values are 'cluster', 'indices', and 'shards'.
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {string} [params.timeout=30s] - The amount of time to wait for a response from the cluster.
+ * @param {string} [params.wait_for_active_shards=0] - Wait until the specified number of shards is active before returning a response. 'all' for all shards
+ * @param {string} [params.wait_for_nodes] - Wait for N number of nodes. Use 12 for exact match, >12 and <12 for range.
+ * @param {string} [params.wait_for_events] - Wait until all currently queued events with the given priority are processed. Supported values are 'immediate', 'urgent', 'high', 'normal', 'low', and 'languid'.
+ * @param {boolean} [params.wait_for_no_relocating_shards=false] - Whether to wait until there are no relocating shards in the cluster.
+ * @param {boolean} [params.wait_for_no_initializing_shards=false] - Whether to wait until there are no initializing shards in the cluster.
+ * @param {string} [params.wait_for_status] - Wait until the cluster health reaches the specified status or better. Supported values are 'green', 'yellow', and 'red'.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cluster-health/#response Cluster Health Response}
+ */
 ClusterApi.prototype.health = function clusterHealthApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -289,6 +402,19 @@ ClusterApi.prototype.health = function clusterHealthApi(params, options, callbac
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Get a list of any cluster-level changes
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.pendingTasks = function clusterPendingTasksApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -310,6 +436,19 @@ ClusterApi.prototype.pendingTasks = function clusterPendingTasksApi(params, opti
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Updates the cluster voting config exclusions by node ids or node names.
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {string} [params.node_names] - A comma-separated list of the persistent ids of the nodes to exclude from the voting configuration. If specified, you may not also specify node_names.
+ * @param {string} [params.node_ids] - A comma-separated list of the names of the nodes to exclude from the voting configuration. If specified, you may not also specify node_ids.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.postVotingConfigExclusions = function clusterPostVotingConfigExclusionsApi(
   params,
   options,
@@ -335,6 +474,22 @@ ClusterApi.prototype.postVotingConfigExclusions = function clusterPostVotingConf
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Creates or updates a component template
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {string} params.name - The name of the component template.
+ * @param {object} params.body - The template definition.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {boolean} [params.create=false] - Whether the index template should only be added if new or can also replace an existing one.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.putComponentTemplate = function clusterPutComponentTemplateApi(
   params,
   options,
@@ -370,6 +525,22 @@ ClusterApi.prototype.putComponentTemplate = function clusterPutComponentTemplate
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Updates the cluster settings.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cluster-settings/ OpenSearch - Cluster Settings}
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {boolean} [params.flat_settings] Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {string} [params.timeout=30s] - The amount of time to wait for a response from the cluster.
+ * @param {object} params.body - The settings to be updated. Can be either 'transient' or 'persistent' (survives cluster restart).
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.putSettings = function clusterPutSettingsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -397,6 +568,17 @@ ClusterApi.prototype.putSettings = function clusterPutSettingsApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * This operation provides connection information for any remote OpenSearch clusters that you’ve configured for the local cluster, such as the remote cluster alias, connection mode (sniff or proxy), IP addresses for seed nodes, and timeout settings.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/remote-info/ OpenSearch - Remote cluster information}
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/remote-info/#response Remote cluster information }
+ */
 ClusterApi.prototype.remoteInfo = function clusterRemoteInfoApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -418,6 +600,23 @@ ClusterApi.prototype.remoteInfo = function clusterRemoteInfoApi(params, options,
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Allows to manually change the allocation of individual shards in the cluster.
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {object} [params.body] - The definition of 'commands' to perform ('move', 'cancel', 'allocate')
+ * @param {boolean} [params.dry_run] - Simulate the operation only and return the resulting state
+ * @param {boolean} [params.explain] - Return an explanation of why the commands can or cannot be executed
+ * @param {boolean} [params.retry_failed] - Retries allocation of shards that are blocked due to too many subsequent allocation failures
+ * @param {string | string[]} [params.metric] - Limit the information returned to the specified metrics. Defaults to all but metadata (options: _all, blocks, metadata, nodes, routing_table, cluster_manager_node, version)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.reroute = function clusterRerouteApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -439,6 +638,28 @@ ClusterApi.prototype.reroute = function clusterRerouteApi(params, options, callb
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Get comprehensive information about the state of the cluster.
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {string | string[]} [params.metric] - Limit the information returned to the specified metrics. Defaults to all but metadata (options: _all, blocks, metadata, nodes, routing_table, cluster_manager_node, version).
+ * @param {string | string[]} [params.index] - List of index names; use '_all' or empty string to perform the operation on all indices.
+ * @param {boolean} [params.local=false] - Whether to return information from the local node only instead of from the cluster manager node.
+ * @param {string} [params.cluster_manager_timeout=30s] - The amount of time to wait for a connection to the cluster manager node.
+ * @param {boolean} [params.flat_settings=false] - Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings.
+ * @param {number} [params.wait_for_metadata_version] - Wait for the metadata version to be equal or greater than the specified metadata version.
+ * @param {string} [params.wait_for_timeout=30s] - The maximum time to wait for wait_for_metadata_version before timing out
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards=open] - Expands wildcard expressions to concrete indices. Combine multiple values with commas. Supported values are 'all', 'open', 'closed', 'hidden', and 'none'. Default is 'open'.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 ClusterApi.prototype.state = function clusterStateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -481,6 +702,22 @@ ClusterApi.prototype.state = function clusterStateApi(params, options, callback)
 
   return this.transport.request(request, options, callback);
 };
+
+/**
+ * The CAT aliases operation lists the mapping of aliases to indices, plus routing and filtering information.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/cluster-stats/ OpenSearch - Cluster stats}
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params
+ * @param {string | string[]} [params.node_id] - A comma-separated list of node IDs or names to limit the returned information; use '_local' to return information from the node you're connecting to, leave empty to get information from all nodes.
+ *
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/cluster-stats/#response Cluster stats Response}
+ */
 
 ClusterApi.prototype.stats = function clusterStatsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);

--- a/api/api/count.js
+++ b/api/api/count.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Count */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'ignore_unavailable',
@@ -66,6 +68,32 @@ const snakeCase = {
   errorTrace: 'error_trace',
   filterPath: 'filter_path',
 };
+
+/**
+ * The count API gives you quick access to the number of documents that match a query. You can also use it to check the document count of an index, data stream, or cluster.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/count/ OpenSearch - Bulk}
+ *
+ * @memberOf API-Count
+ *
+ * @param {Object} params
+ * @param {boolean} [params.allow_no_indices=false] - If false, the request returns an error if any wildcard expression or index alias targets any closed or missing indices.
+ * @param {string} [params.analyzer] - The analyzer to use in the query string.
+ * @param {boolean} [params.analyze_wildcard=false] - Specifies whether to analyze wildcard and prefix queries.
+ * @param {string} [params.default_operator='OR'] - Indicates whether the default operator for a string query should be 'AND' or 'OR'.
+ * @param {string} [params.df] - The default field in case a field prefix is not provided in the query string.
+ * @param {string} [params.expand_wildcards=open] - Expands wildcard expressions to concrete indices. Combine multiple values with commas. Supported values are 'all', 'open', 'closed', 'hidden', and 'none'.
+ * @param {boolean} [params.ignore_unavailable=false] - Specifies whether to include missing or closed indices in the response.
+ * @param {boolean} [params.lenient=false] - Specifies whether OpenSearch should accept requests if queries have format errors (for example, querying a text field for an integer).
+ * @param {number} [params.min_score] - Include only documents with a minimum '_score' value in the result.
+ * @param {string} [params.routing] - Value used to route the operation to a specific shard.
+ * @param {string} [params.preference] - Specifies which shard or node OpenSearch should perform the count operation on.
+ * @param {number} [params.terminate_after] - The maximum number of documents OpenSearch should process before terminating the request.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/count/#response Count Response}
+ */
 
 function countApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);

--- a/api/api/create.js
+++ b/api/api/create.js
@@ -54,6 +54,32 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Adds a document with a predefined ID to an index.
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/index-document/ OpenSearch - Index Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {string} params.id - A unique identifier to attach to the document.
+ * @param {Object} params.body - The content of the document.
+ * @param {number} [params.if_seq_no] - Only perform the index operation if the document has the specified sequence number.
+ * @param {number} [params.if_primary_term] - Only perform the index operation if the document has the specified primary term.
+ * @param {string} [params.pipeline] - Route the index operation to a certain pipeline.
+ * @param {string} [params.routing] - value used to assign the index operation to a specific shard.
+ * @param {string} [params.refresh=false] - If true, OpenSearch refreshes shards to make the operation visible to searching. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.timeout=1m] - How long to wait for a response from the cluster.
+ * @param {number} [params.version] - The document’s version number.
+ * @param {number} [params.version_type] - Specific version type (options: 'external' and 'external_gte')
+ * @param {string} [params.wait_for_active_shards] - The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
+ * @param {boolean} [params.require_alias=false] - Specifies whether the target index must be an index alias.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/index-document/#response Index Response}
+ */
 function createApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/dangling_indices.js
+++ b/api/api/dangling_indices.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Dangling-Indices */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'accept_data_loss',
@@ -57,6 +59,22 @@ function DanglingIndicesApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+/**
+ * Deletes the specified dangling index
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/ OpenSearch - Dangling Indexes}
+ * @memberOf API-Dangling-Indices
+ *
+ * @param {Object} params
+ * @param {string} params.index_uuid - The UUID of the dangling index
+ * @param {boolean} [params.accept_data_loss] - Must be set to true in order to delete the dangling index
+ * @param {string} [params.timeout=30s] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 DanglingIndicesApi.prototype.deleteDanglingIndex = function danglingIndicesDeleteDanglingIndexApi(
   params,
   options,
@@ -90,6 +108,22 @@ DanglingIndicesApi.prototype.deleteDanglingIndex = function danglingIndicesDelet
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Imports the specified dangling index
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/ OpenSearch - Dangling Indexes}
+ * @memberOf API-Dangling-Indices
+ *
+ * @param {Object} params
+ * @param {string} params.index_uuid - The UUID of the dangling index
+ * @param {boolean} [params.accept_data_loss] - Must be set to true in order to delete the dangling index
+ * @param {string} [params.timeout=30s] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 DanglingIndicesApi.prototype.importDanglingIndex = function danglingIndicesImportDanglingIndexApi(
   params,
   options,
@@ -123,6 +157,17 @@ DanglingIndicesApi.prototype.importDanglingIndex = function danglingIndicesImpor
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Retrieve all dangling indices.
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/ OpenSearch - Dangling Indexes}
+ * @memberOf API-Dangling-Indices
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 DanglingIndicesApi.prototype.listDanglingIndices = function danglingIndicesListDanglingIndicesApi(
   params,
   options,

--- a/api/api/delete.js
+++ b/api/api/delete.js
@@ -57,6 +57,29 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Delete a document
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/update-document/ OpenSearch - Update Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {string} params.id - A unique identifier to attach to the document.
+ * @param {number} [params.if_seq_no] - Only perform the delete operation if the document has the specified sequence number.
+ * @param {number} [params.if_primary_term] - Only perform the delete operation if the document has the specified primary term.
+ * @param {string} [params.routing] - Value used to assign the index operation to a specific shard.
+ * @param {string} [params.refresh=false] - If true, OpenSearch refreshes shards to make the operation visible to searching. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.timeout=1m] - How long to wait for a response from the cluster.
+ * @param {string} [params.wait_for_active_shards] - The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
+ * @param {number} [params.version] - The document’s version number.
+ * @param {number} [params.version_type] - Specific version type (options: 'external' and 'external_gte')
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/update-document/#response Update Response}
+ */
 function deleteApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/delete_by_query.js
+++ b/api/api/delete_by_query.js
@@ -98,6 +98,54 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Deletes documents matching the provided query.
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/delete-by-query/ OpenSearch - Delete by query}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names to search; use '_all' or empty string to perform the operation on all indices
+ * @param {Object} params.body - The search definition using the Query DSL
+ * @param {string} [params.analyzer] - The analyzer to use for the query string
+ * @param {boolean} [params.analyze_wildcard=false] - Specify whether wildcard and prefix queries should be analyzed
+ * @param {string} [params.default_operator=OR] - The default operator for query string query (options: AND, OR)
+ * @param {string} [params.df] - The field to use as default where no field prefix is given in the query string
+ * @param {number} [params.from=0] - Starting offset
+ * @param {boolean} [params.ignore_unavailable=false] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices=true] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes '_all' string or when no indices have been specified)
+ * @param {string} [params.conflicts] - What to do when the delete-by-query hits version conflicts? (options: abort, proceed)
+ * @param {string} [params.expand_wildcards=open] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.lenient=false] - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+ * @param {string} [params.preference] - Specify the node or shard the operation should be performed on (default: random)
+ * @param {string} [params.q] - Query in the Lucene query string syntax
+ * @param {string} [params.routing] - A comma-separated list of specific routing values
+ * @param {string} [params.scroll] - Specify how long a consistent view of the index should be maintained for scrolled search
+ * @param {string} [params.search_type] - Search operation type (options: query_then_fetch, dfs_query_then_fetch)
+ * @param {string} [params.search_timeout] - Explicit timeout for each search request. Defaults to no timeout.
+ * @param {number} [params.size] - Deprecated, please use 'max_docs' instead
+ * @param {number} [params.max_docs] - Maximum number of documents to process (default: all documents)
+ * @param {string} [params.sort] - A comma-separated list of <field>:<direction> pairs
+ * @param {string} [params._source] - True or false to return the _source field or not, or a list of fields to return
+ * @param {string} [params._source_excludes] - A list of fields to exclude from the returned _source field
+ * @param {string} [params._source_includes] - A list of fields to extract and return from the _source field
+ * @param {number} [params.terminate_after] - The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
+ * @param {string} [params.stats] - Specific 'tag' of the request for logging and statistical purposes
+ * @param {boolean} [params.version] - Specify whether to return document version as part of a hit
+ * @param {boolean} [params.request_cache] - Specify if request cache should be used for this request or not, defaults to index level setting
+ * @param {boolean} [params.refresh=false] - Should the effected indexes be refreshed?
+ * @param {string} [params.timeout=1m] - time each individual bulk request should wait for shards that are unavailable.
+ * @param {string} [params.wait_for_active_shards=1] - Sets the number of shard copies that must be active before proceeding with the delete-by-query operation. 1 means the primary shard only. Set to 'all' for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+ * @param {number} [params.scroll_size=1000] - Size on the scroll request powering the delete-by-query
+ * @param {boolean} [params.wait_for_completion] - Should the request should block until the delete-by-query is complete.
+ * @param {number} [params.requests_per_second=-1] - The throttle for this request in sub-requests per second. -1 means no throttle.
+ * @param {string} [params.slices=1] - The number of slices this task should be divided into. 1 means the task isn't sliced into subtasks. Can be set to 'auto'.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/delete-by-query/#response Delete by query Response}
+ */
 function deleteByQueryApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/delete_by_query_rethrottle.js
+++ b/api/api/delete_by_query_rethrottle.js
@@ -47,6 +47,20 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Changes the number of requests per second for a particular Delete By Query operation.
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.task_id - The task id to rethrottle
+ * @param {number} params.requests_per_second - The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function deleteByQueryRethrottleApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/delete_script.js
+++ b/api/api/delete_script.js
@@ -50,6 +50,20 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Delete a stored script.
+ * @memberOf API-Script
+ *
+ * @param {Object} params
+ * @param {string} params.id - Stored script or search template name
+ * @param {string} [params.timeout=30s] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function deleteScriptApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/exists.js
+++ b/api/api/exists.js
@@ -63,6 +63,31 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Check whether a document exists
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/get-documents/ OpenSearch - Get Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {string} params.id - Document ID.
+ * @param {string} [params.preference] - Specifies a preference of which shard to retrieve results from. Available options are '_local', which tells the operation to retrieve results from a locally allocated shard replica, and a custom string value assigned to a specific shard replica. By default, OpenSearch executes get document operations on random shards.
+ * @param {boolean} [params.realtime=true] - Specifies whether the operation should run in realtime. If false, the operation waits for the index to refresh to analyze the source to retrieve data, which makes the operation near-realtime.
+ * @param {boolean} [params.refresh=false] - If true, OpenSearch refreshes shards to make the get operation available to search results. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.routing] - A value used to route the operation to a specific shard.
+ * @param {boolean} [params.stored_fields=false] - Whether the get operation should retrieve fields stored in the index.
+ * @param {string} [params._source=true] - Whether to include the '_source' field in the response body.
+ * @param {string} [params._source_excludes] - A comma-separated list of source fields to exclude in the query response.
+ * @param {string} [params._source_includes] - A comma-separated list of source fields to include in the query response.
+ * @param {number} [params.version] - The document’s version number.
+ * @param {number} [params.version_type] - Specific version type (options: 'external' and 'external_gte')
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/get-documents/#response Get Response}
+ */
 function existsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/exists_source.js
+++ b/api/api/exists_source.js
@@ -32,6 +32,31 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/**
+ * Check whether a document source exists
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/get-documents/ OpenSearch - Get Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {string} params.id - Document ID.
+ * @param {string} [params.preference] - Specifies a preference of which shard to retrieve results from. Available options are '_local', which tells the operation to retrieve results from a locally allocated shard replica, and a custom string value assigned to a specific shard replica. By default, OpenSearch executes get document operations on random shards.
+ * @param {boolean} [params.realtime=true] - Specifies whether the operation should run in realtime. If false, the operation waits for the index to refresh to analyze the source to retrieve data, which makes the operation near-realtime.
+ * @param {boolean} [params.refresh=false] - If true, OpenSearch refreshes shards to make the get operation available to search results. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.routing] - A value used to route the operation to a specific shard.
+ * @param {boolean} [params.stored_fields=false] - Whether the get operation should retrieve fields stored in the index.
+ * @param {string} [params._source=true] - Whether to include the '_source' field in the response body.
+ * @param {string} [params._source_excludes] - A comma-separated list of source fields to exclude in the query response.
+ * @param {string} [params._source_includes] - A comma-separated list of source fields to include in the query response.
+ * @param {number} [params.version] - The document’s version number.
+ * @param {number} [params.version_type] - Specific version type (options: 'external' and 'external_gte')
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/get-documents/#response Get Response}
+ */
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'preference',

--- a/api/api/explain.js
+++ b/api/api/explain.js
@@ -66,6 +66,33 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Returns information about why a specific matches (or doesn't match) a query.
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/explain/ OpenSearch - Explain}
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} [params.id] - The document ID
+ * @param {string} [params.index] - The name of the index
+ * @param {Object} [params.body] - The query definition using the Query DSL
+ * @param {string} [params.analyzer] - The analyzer to use for the query string
+ * @param {boolean} [params.analyze_wildcard=false] - Specify whether wildcard and prefix queries should be analyzed
+ * @param {string} [params.default_operator=OR] - The default operator for query string query (options: AND, OR)
+ * @param {string} [params.df] - The default field for query string query (default: _all)
+ * @param {string} [params.stored_fields] - A comma-separated list of stored fields to return in the response
+ * @param {boolean} [params.lenient] - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+ * @param {string} [params.preference] - Specify the node or shard the operation should be performed on (default: random)
+ * @param {string} [params.q] - Query in the Lucene query string syntax
+ * @param {string} [params.routing] - Specific routing value
+ * @param {string} [params._source=true] - Whether to include the '_source' field in the response body.
+ * @param {string} [params._source_excludes] - A comma-separated list of source fields to exclude in the query response.
+ * @param {string} [params._source_includes] - A comma-separated list of source fields to include in the query response.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function explainApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/features.js
+++ b/api/api/features.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Features */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'cluster_manager_timeout',
@@ -54,6 +56,18 @@ function FeaturesApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+/**
+ * Gets a list of features
+ * @memberOf API-Features
+ *
+ * @param {Object} params
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 FeaturesApi.prototype.getFeatures = function featuresGetFeaturesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -75,6 +89,16 @@ FeaturesApi.prototype.getFeatures = function featuresGetFeaturesApi(params, opti
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Resets the internal state of features, usually by deleting system indices
+ * @memberOf API-Features
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 FeaturesApi.prototype.resetFeatures = function featuresResetFeaturesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/field_caps.js
+++ b/api/api/field_caps.js
@@ -54,6 +54,25 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Returns the information about the capabilities of fields among multiple indices.
+ * <br/> See also: {@link https://opensearch.org/docs/latest/opensearch/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations OpenSearch - Alias}
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {string} [params.fields] - A comma-separated list of field names
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.include_unmapped] - Indicates whether unmapped fields should be included in the response.
+ * @param {Object} [params.body] - An index filter specified with the Query DSL
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function fieldCapsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/get.js
+++ b/api/api/get.js
@@ -63,6 +63,31 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Retrieve a document
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/get-documents/ OpenSearch - Get Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {string} params.id - Document ID.
+ * @param {string} [params.preference] - Specifies a preference of which shard to retrieve results from. Available options are '_local', which tells the operation to retrieve results from a locally allocated shard replica, and a custom string value assigned to a specific shard replica. By default, OpenSearch executes get document operations on random shards.
+ * @param {boolean} [params.realtime=true] - Specifies whether the operation should run in realtime. If false, the operation waits for the index to refresh to analyze the source to retrieve data, which makes the operation near-realtime.
+ * @param {boolean} [params.refresh=false] - If true, OpenSearch refreshes shards to make the get operation available to search results. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.routing] - A value used to route the operation to a specific shard.
+ * @param {boolean} [params.stored_fields=false] - Whether the get operation should retrieve fields stored in the index.
+ * @param {string} [params._source=true] - Whether to include the '_source' field in the response body.
+ * @param {string} [params._source_excludes] - A comma-separated list of source fields to exclude in the query response.
+ * @param {string} [params._source_includes] - A comma-separated list of source fields to include in the query response.
+ * @param {number} [params.version] - The document’s version number.
+ * @param {number} [params.version_type] - Specific version type (options: 'external' and 'external_gte')
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/get-documents/#response Get Response}
+ */
 function getApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/get_script.js
+++ b/api/api/get_script.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Script */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'cluster_manager_timeout',
@@ -49,6 +51,20 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Retrieves a stored script.
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/script-apis/get-stored-script/ OpenSearch - Get Stored Script}
+ * @memberOf API-Script
+ *
+ * @param {Object} params
+ * @param {string} params.id - Stored script or search template name
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function getScriptApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/get_script_context.js
+++ b/api/api/get_script_context.js
@@ -36,6 +36,17 @@ const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = 
 const acceptedQuerystring = ['pretty', 'human', 'error_trace', 'source', 'filter_path'];
 const snakeCase = { errorTrace: 'error_trace', filterPath: 'filter_path' };
 
+/**
+ * Retrieves all contexts for stored scripts.
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/script-apis/get-script-contexts/ OpenSearch - Get stored script contexts}
+ * @memberOf API-Script
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function getScriptContextApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/get_script_languages.js
+++ b/api/api/get_script_languages.js
@@ -36,6 +36,17 @@ const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = 
 const acceptedQuerystring = ['pretty', 'human', 'error_trace', 'source', 'filter_path'];
 const snakeCase = { errorTrace: 'error_trace', filterPath: 'filter_path' };
 
+/**
+ * The get script language API operation retrieves all supported script languages and their contexts.
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/script-apis/get-script-language/ OpenSearch - Get script language}
+ * @memberOf API-Script
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function getScriptLanguagesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/get_source.js
+++ b/api/api/get_source.js
@@ -61,6 +61,31 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Retrieve the source of a document
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/get-documents/ OpenSearch - Get Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {string} params.id - Document ID.
+ * @param {string} [params.preference] - Specifies a preference of which shard to retrieve results from. Available options are '_local', which tells the operation to retrieve results from a locally allocated shard replica, and a custom string value assigned to a specific shard replica. By default, OpenSearch executes get document operations on random shards.
+ * @param {boolean} [params.realtime=true] - Specifies whether the operation should run in realtime. If false, the operation waits for the index to refresh to analyze the source to retrieve data, which makes the operation near-realtime.
+ * @param {boolean} [params.refresh=false] - If true, OpenSearch refreshes shards to make the get operation available to search results. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.routing] - A value used to route the operation to a specific shard.
+ * @param {boolean} [params.stored_fields=false] - Whether the get operation should retrieve fields stored in the index.
+ * @param {string} [params._source=true] - Whether to include the '_source' field in the response body.
+ * @param {string} [params._source_excludes] - A comma-separated list of source fields to exclude in the query response.
+ * @param {string} [params._source_includes] - A comma-separated list of source fields to include in the query response.
+ * @param {number} [params.version] - The document’s version number.
+ * @param {number} [params.version_type] - Specific version type (options: 'external' and 'external_gte')
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/get-documents/#response Get Response}
+ */
 function getSourceApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/index.js
+++ b/api/api/index.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Document */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'wait_for_active_shards',
@@ -61,6 +63,33 @@ const snakeCase = {
   errorTrace: 'error_trace',
   filterPath: 'filter_path',
 };
+
+/**
+ * Adds a document to an index.
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/index-document/ OpenSearch - Index Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {Object} params.body - The content of the document.
+ * @param {string} [params.id] - A unique identifier to attach to the document.
+ * @param {number} [params.if_seq_no] - Only perform the index operation if the document has the specified sequence number.
+ * @param {number} [params.if_primary_term] - Only perform the index operation if the document has the specified primary term.
+ * @param {string} [params.pipeline] - Route the index operation to a certain pipeline.
+ * @param {string} [params.routing] - value used to assign the index operation to a specific shard.
+ * @param {string} [params.refresh=false] - If true, OpenSearch refreshes shards to make the operation visible to searching. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.timeout=1m] - How long to wait for a response from the cluster.
+ * @param {number} [params.version] - The document’s version number.
+ * @param {number} [params.version_type] - Specific version type (options: 'external' and 'external_gte')
+ * @param {string} [params.wait_for_active_shards] - The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
+ * @param {boolean} [params.require_alias=false] - Specifies whether the target index must be an index alias.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/index-document/#response Index Response}
+ */
 
 function indexApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);

--- a/api/api/indices.js
+++ b/api/api/indices.js
@@ -29,6 +29,8 @@
 
 'use strict';
 
+/** @namespace API-Index */
+
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
@@ -128,6 +130,25 @@ function IndicesApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+/**
+ * Adds a block to an index.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma separated list of indices to add a block to
+ * @param {string} params.block - The block to add (one of read, write, read_only or metadata)
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.addBlock = function indicesAddBlockApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -165,6 +186,21 @@ IndicesApi.prototype.addBlock = function indicesAddBlockApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Performs the analysis process on a text and return the tokens breakdown of the text.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/analyze-apis/perform-text-analysis/ OpenSearch - Perform text analysis}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - The name of the index to scope the operation
+ * @param {Object} [params.body] - Define analyzer/tokenizer parameters and the text on which the analysis should be performed
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.analyze = function indicesAnalyzeApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -191,6 +227,27 @@ IndicesApi.prototype.analyze = function indicesAnalyzeApi(params, options, callb
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Clears all or specific caches for one or more indices.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/clear-index-cache/ OpenSearch - Clear index or data stream cache}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index name to limit the operation
+ * @param {boolean} [params.fielddata] - Clear field data
+ * @param {string} [params.fields] - A comma-separated list of fields to clear when using the `fielddata` parameter (default: all)
+ * @param {boolean} [params.query] - Clear query caches
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.request] - Clear request cache
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.clearCache = function indicesClearCacheApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -217,6 +274,25 @@ IndicesApi.prototype.clearCache = function indicesClearCacheApi(params, options,
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Clones an index
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/clone/ OpenSearch - Clone Index}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - The name of the source index to clone
+ * @param {string} params.target - The name of the target index to clone into
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {string} [params.wait_for_active_shards] - Set the number of active shards to wait for on the cloned index before the operation returns.
+ * @param {Object} [params.body] - The configuration for the target index (`settings` and `aliases`)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.clone = function indicesCloneApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -254,6 +330,26 @@ IndicesApi.prototype.clone = function indicesCloneApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Closes an index.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/close-index/ OpenSearch - Close Index}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma separated list of indices to close
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {string} [params.wait_for_active_shards] - Sets the number of active shards to wait for before the operation returns. Set to `index-setting` to wait according to the index setting `index.write.wait_for_active_shards`, or `all` to wait for all shards, or an integer. Defaults to `0`.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.close = function indicesCloseApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -281,6 +377,24 @@ IndicesApi.prototype.close = function indicesCloseApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Creates an index
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/create-index/ OpenSearch - Create Index}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {Object} [params.body] - The configuration for the index (`settings` and `mappings`)
+ * @param {string} [params.wait_for_active_shards] - Set the number of active shards to wait for before the operation returns.
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.create = function indicesCreateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -308,6 +422,25 @@ IndicesApi.prototype.create = function indicesCreateApi(params, options, callbac
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Deletes an index.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/delete-index/ OpenSearch - Delete Index}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {boolean} [params.ignore_unavailable=false] - Ignore unavailable indexes
+ * @param {boolean} [params.allow_no_indices=false] - Ignore if a wildcard expression resolves to no concrete indices
+ * @param {string} [params.expand_wildcards=open] - Whether wildcard expressions should get expanded to open or closed indices (options: open, closed, hidden, none, all)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.delete = function indicesDeleteApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -335,6 +468,23 @@ IndicesApi.prototype.delete = function indicesDeleteApi(params, options, callbac
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Deletes an alias.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-alias/ OpenSearch - Index Aliases}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names (supports wildcards); use `_all` for all indices
+ * @param {string} params.name - A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.
+ * @param {string} [params.timeout] - Explicit timestamp for the document
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.deleteAlias = function indicesDeleteAliasApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -377,6 +527,22 @@ IndicesApi.prototype.deleteAlias = function indicesDeleteAliasApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Deletes an index template.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-templates/ OpenSearch - Index Templates}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.name - The name of the template
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.deleteIndexTemplate = function indicesDeleteIndexTemplateApi(
   params,
   options,
@@ -408,6 +574,21 @@ IndicesApi.prototype.deleteIndexTemplate = function indicesDeleteIndexTemplateAp
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Deletes an index template (Deprecated. Use IndicesApi#deleteIndexTemplate instead)
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.name - The name of the template
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.deleteTemplate = function indicesDeleteTemplateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -435,6 +616,7 @@ IndicesApi.prototype.deleteTemplate = function indicesDeleteTemplateApi(params, 
   return this.transport.request(request, options, callback);
 };
 
+// TODO: Remove. Experimental feature added in ES 7.15
 IndicesApi.prototype.diskUsage = function indicesDiskUsageApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -462,6 +644,26 @@ IndicesApi.prototype.diskUsage = function indicesDiskUsageApi(params, options, c
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about whether a particular index exists.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/exists/ OpenSearch - Index Exists}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ * @param {boolean} [params.ignore_unavailable=false] - Ignore unavailable indexes
+ * @param {boolean} [params.allow_no_indices=false] - Ignore if a wildcard expression resolves to no concrete indices
+ * @param {string} [params.expand_wildcards=open] - Whether wildcard expressions should get expanded to open or closed indices (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.flat_settings=false] - Return settings in flat format
+ * @param {boolean} [params.include_defaults] - Whether to return all default setting for each of the indices.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.exists = function indicesExistsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -489,6 +691,25 @@ IndicesApi.prototype.exists = function indicesExistsApi(params, options, callbac
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about whether a particular alias exists.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-alias/ OpenSearch - Index Aliases}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.name - A comma-separated list of alias names to return
+ * @param {string} [params.index] - A comma-separated list of index names to filter aliases
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.existsAlias = function indicesExistsAliasApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -521,6 +742,23 @@ IndicesApi.prototype.existsAlias = function indicesExistsAliasApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about whether a particular index template exists.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-templates/ OpenSearch - Index Templates}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.name - The name of the template
+ * @param {boolean} [params.flat_settings=false] - Return settings in flat format
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.existsIndexTemplate = function indicesExistsIndexTemplateApi(
   params,
   options,
@@ -552,6 +790,22 @@ IndicesApi.prototype.existsIndexTemplate = function indicesExistsIndexTemplateAp
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about whether a particular index template exists. (Deprecated. Use IndicesApi#existsIndexTemplate instead)
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.name - The comma separated names of the index templates
+ * @param {boolean} [params.flat_settings=false] - Return settings in flat format
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.existsTemplate = function indicesExistsTemplateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -579,6 +833,7 @@ IndicesApi.prototype.existsTemplate = function indicesExistsTemplateApi(params, 
   return this.transport.request(request, options, callback);
 };
 
+// TODO: Remove. Experimental feature added in ES 7.15
 IndicesApi.prototype.fieldUsageStats = function indicesFieldUsageStatsApi(
   params,
   options,
@@ -610,6 +865,24 @@ IndicesApi.prototype.fieldUsageStats = function indicesFieldUsageStatsApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Performs the flush operation on one or more indices.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string for all indices
+ * @param {boolean} [params.force] - Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)
+ * @param {boolean} [params.wait_if_ongoing=true] - If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. If set to false the flush will be skipped iff if another flush operation is already running.
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.flush = function indicesFlushApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -636,6 +909,25 @@ IndicesApi.prototype.flush = function indicesFlushApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Performs the force merge operation on one or more indices.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {boolean} [params.flush=true] - Specify whether the index should be flushed after performing the operation
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {number} [params.max_num_segments] - The number of segments the index should be merged into (default: dynamic)
+ * @param {boolean} [params.only_expunge_deletes] - Specify whether the operation should only expunge deleted documents
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.forcemerge = function indicesForcemergeApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -662,6 +954,27 @@ IndicesApi.prototype.forcemerge = function indicesForcemergeApi(params, options,
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about one or more indices.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/get-index/ OpenSearch - Get Index}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ * @param {boolean} [params.ignore_unavailable=false] - Ignore unavailable indexes
+ * @param {boolean} [params.allow_no_indices=false] - Ignore if a wildcard expression resolves to no concrete indices
+ * @param {string} [params.expand_wildcards=open] - Whether wildcard expressions should get expanded to open or closed indices (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.flat_settings=false] - Return settings in flat format
+ * @param {boolean} [params.include_defaults] - Whether to return all default setting for each of the indices.
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.get = function indicesGetApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -689,6 +1002,25 @@ IndicesApi.prototype.get = function indicesGetApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns an alias.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-alias/ OpenSearch - Index Aliases}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.name] - A comma-separated list of alias names to return
+ * @param {string} [params.index] - A comma-separated list of index names to filter aliases
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.getAlias = function indicesGetAliasApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -721,6 +1053,26 @@ IndicesApi.prototype.getAlias = function indicesGetAliasApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns mapping for one or more fields.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/mappings/ OpenSearch - Mapping}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.fields - A comma-separated list of fields
+ * @param {string} [params.index] - A comma-separated list of index names
+ * @param {boolean} [params.include_defaults] - Whether the default mapping values should be returned as well
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.getFieldMapping = function indicesGetFieldMappingApi(
   params,
   options,
@@ -789,6 +1141,23 @@ IndicesApi.prototype.getFieldMapping = function indicesGetFieldMappingApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns an index template.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-templates/ OpenSearch - Index Templates}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.name] - The comma separated names of the index templates
+ * @param {boolean} [params.flat_setting=false] - Return settings in flat format
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.getIndexTemplate = function indicesGetIndexTemplateApi(
   params,
   options,
@@ -819,6 +1188,25 @@ IndicesApi.prototype.getIndexTemplate = function indicesGetIndexTemplateApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns mappings for one or more indices.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/mappings/ OpenSearch - Mapping}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node (Deprecated)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.getMapping = function indicesGetMappingApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -851,6 +1239,28 @@ IndicesApi.prototype.getMapping = function indicesGetMappingApi(params, options,
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns settings for one or more indices.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/get-settings/ OpenSearch - Get Settings}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {string} [params.name] - The name of the settings that should be included
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.flat_settings=false] - Return settings in flat format
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ * @param {boolean} [params.include_defaults] - Whether to return all default setting for each of the indices.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.getSettings = function indicesGetSettingsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -883,6 +1293,22 @@ IndicesApi.prototype.getSettings = function indicesGetSettingsApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns an index template. (Deprecated. Use IndicesApi#getIndexTemplate instead)
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.name] - The comma separated names of the index templates
+ * @param {boolean} [params.flat_settings=false] - Return settings in flat format
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.local=false] - Return local information, do not retrieve the state from cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.getTemplate = function indicesGetTemplateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -909,6 +1335,22 @@ IndicesApi.prototype.getTemplate = function indicesGetTemplateApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns a progress status of current upgrade. (Deprecated. Use API-Document#reindex instead)
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.getUpgrade = function indicesGetUpgradeApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -930,6 +1372,26 @@ IndicesApi.prototype.getUpgrade = function indicesGetUpgradeApi(params, options,
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * ROpens an index.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/open-index/ OpenSearch - Open Index}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma separated list of indices to open
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {string} [params.wait_for_active_shards] - Sets the number of active shards to wait for before the operation returns.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.open = function indicesOpenApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -957,6 +1419,24 @@ IndicesApi.prototype.open = function indicesOpenApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Creates or updates an alias.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-alias/ OpenSearch - Index Aliases}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.
+ * @param {string} params.name - The name of the alias to be created or updated
+ * @param {string} [params.timeout] - Explicit timestamp for the document
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {Object} [params.body] - The settings for the alias, such as `routing` or `filter`
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.putAlias = function indicesPutAliasApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -999,6 +1479,24 @@ IndicesApi.prototype.putAlias = function indicesPutAliasApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Creates or updates an index template.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-templates/ OpenSearch - Index Templates}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.name - The name of the template
+ * @param {Object} params.body - The template definition
+ * @param {boolean} [params.create] - Whether the index template should only be added if new or can also replace an existing one
+ * @param {string} [params.cause] - User defined reason for creating/updating the index template
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.putIndexTemplate = function indicesPutIndexTemplateApi(
   params,
   options,
@@ -1034,6 +1532,27 @@ IndicesApi.prototype.putIndexTemplate = function indicesPutIndexTemplateApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Updates index mappings.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/put-mapping/ OpenSearch - Create or Update Mapping}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
+ * @param {Object} params.body - The mapping definition
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.write_index_only] - When true, applies mappings only to the write index of an alias or data stream
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.putMapping = function indicesPutMappingApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1084,6 +1603,28 @@ IndicesApi.prototype.putMapping = function indicesPutMappingApi(params, options,
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Updates the index settings.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/update-settings/ OpenSearch - Update Settings}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {Object} params.body - The index settings to be updated
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {boolean} [params.preserve_existing=false] - Whether to update existing settings. If set to `true` existing settings on an index remain unchanged
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.flat_settings=false] - Return settings in flat format
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.putSettings = function indicesPutSettingsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1116,6 +1657,23 @@ IndicesApi.prototype.putSettings = function indicesPutSettingsApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Creates or updates an index template. (Deprecated. Use IndicesApi#putIndexTemplate instead)
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.name - The name of the template
+ * @param {Object} params.body - The template definition
+ * @param {number} [params.order] - The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)
+ * @param {boolean} [params.create] - Whether the index template should only be added if new or can also replace an existing one
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.putTemplate = function indicesPutTemplateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1147,6 +1705,21 @@ IndicesApi.prototype.putTemplate = function indicesPutTemplateApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about ongoing index shard recoveries.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {boolean} [params.detailed] - Whether to display detailed information about shard recovery
+ * @param {boolean} [params.active_only] - Display only those recoveries that are currently on-going
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.recovery = function indicesRecoveryApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1173,6 +1746,22 @@ IndicesApi.prototype.recovery = function indicesRecoveryApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Performs the refresh operation in one or more indices.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.refresh = function indicesRefreshApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1199,6 +1788,20 @@ IndicesApi.prototype.refresh = function indicesRefreshApi(params, options, callb
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about any matching indices, aliases, and data streams
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.name] - A comma-separated list of names or wildcard expressions
+ * @param {string} [params.expand_wildcards=open] - Whether wildcard expressions should get expanded to open or closed indices (options: open, closed, hidden, none, all)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.resolveIndex = function indicesResolveIndexApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1226,6 +1829,26 @@ IndicesApi.prototype.resolveIndex = function indicesResolveIndexApi(params, opti
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Updates an alias to point to a new index when the existing index is considered to be too large or too old.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/data-streams/#step-5-rollover-a-data-stream OpenSearch - Rollover a data stream}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.alias - The name of the alias to rollover
+ * @param {string} [params.new_index] - The name of the rollover index
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {boolean} [params.dry_run=false] - If set to true the rollover action will only be validated but not actually performed even if a condition matches.
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {string} [params.wait_for_active_shards] - Set the number of active shards to wait for on the newly created rollover index before the operation returns.
+ * @param {Object} [params.body] - The conditions that needs to be met for executing rollover
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.rollover = function indicesRolloverApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1270,6 +1893,23 @@ IndicesApi.prototype.rollover = function indicesRolloverApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Provides low-level information about segments in a Lucene index.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.verbose] - Includes detailed memory usage by Lucene.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.segments = function indicesSegmentsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1296,6 +1936,23 @@ IndicesApi.prototype.segments = function indicesSegmentsApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Provides store information for shard copies of indices.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {string} [params.status] - A comma-separated list of statuses used to filter on shards to get store information for (options: green, yellow, red, all)
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.shardStores = function indicesShardStoresApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1322,6 +1979,26 @@ IndicesApi.prototype.shardStores = function indicesShardStoresApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Allow to shrink an existing index into a new index with fewer primary shards.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/shrink-index/ OpenSearch - Shrink Index}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - The name of the source index to shrink
+ * @param {string} params.target - The name of the target index to shrink into
+ * @param {boolean} [params.copy_settings] - whether or not to copy settings from the source index (defaults to false)
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {string} [params.wait_for_active_shards] - Set the number of active shards to wait for on the shrunken index before the operation returns.
+ * @param {Object} [params.body] - The configuration for the target index (`settings` and `aliases`)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.shrink = function indicesShrinkApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1359,6 +2036,23 @@ IndicesApi.prototype.shrink = function indicesShrinkApi(params, options, callbac
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Simulate matching the given index name against the index templates in the system
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.name - The name of the index (it must be a concrete index name)
+ * @param {Object} [params.body] - New index template definition, which will be included in the simulation, as if it already exists in the system
+ * @param {boolean} [params.create] - Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
+ * @param {string} [params.cause] - User defined reason for dry-run creating the new template for simulation purposes
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.simulateIndexTemplate = function indicesSimulateIndexTemplateApi(
   params,
   options,
@@ -1390,6 +2084,23 @@ IndicesApi.prototype.simulateIndexTemplate = function indicesSimulateIndexTempla
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Simulate resolving the given template name or body (Deprecated. Use IndicesApi#simulateIndexTemplate instead)
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.name] - The name of the index template
+ * @param {boolean} [params.create] - Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
+ * @param {string} [params.cause] - User defined reason for dry-run creating the new template for simulation purposes
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {Object} [params.body] - New index template definition to be simulated, if no index template name is specified
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.simulateTemplate = function indicesSimulateTemplateApi(
   params,
   options,
@@ -1420,6 +2131,26 @@ IndicesApi.prototype.simulateTemplate = function indicesSimulateTemplateApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Allows you to split an existing index into a new index with more primary shards.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/index-apis/split/ OpenSearch - Split Index}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - The name of the source index to split
+ * @param {string} params.target - The name of the target index to split into
+ * @param {boolean} [params.copy_settings] - whether or not to copy settings from the source index (defaults to false)
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ * @param {string} [params.wait_for_active_shards] - Set the number of active shards to wait for on the shrunken index before the operation returns.
+ * @param {Object} [params.body] - The configuration for the target index (`settings` and `aliases`)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.split = function indicesSplitApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1457,6 +2188,30 @@ IndicesApi.prototype.split = function indicesSplitApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Provides statistics on operations happening in an index.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.metric] - Limit the information returned the specific metrics. (options: _all, completion, docs, fielddata, query_cache, flush, get, indexing, merge, request_cache, refresh, search, segments, store, warmer, suggest)
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {string} [params.completion_fields] - A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
+ * @param {string} [params.fielddata_fields] - A comma-separated list of fields for `fielddata` index metric (supports wildcards)
+ * @param {string} [params.fields] - A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)
+ * @param {string} [params.groups] - A comma-separated list of search groups for `search` index metric
+ * @param {string} [params.level] - Return stats aggregated at cluster, index or shard level (options: cluster, indices, shards)
+ * @param {string} [params.types] - A comma-separated list of document types for the `indexing` index metric
+ * @param {boolean} [params.include_segment_file_sizes] - Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)
+ * @param {boolean} [params.include_unloaded_segments] - If set to true segment stats will include stats for segments that are not currently loaded into memory
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.forbid_closed_indices] - If set to false stats will also collected from closed indices if explicitly specified or if expand_wildcards expands to closed indices
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.stats = function indicesStatsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1489,6 +2244,22 @@ IndicesApi.prototype.stats = function indicesStatsApi(params, options, callback)
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Update an alias.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/opensearch/index-alias/ OpenSearch - Index Aliases}
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {Object} params.body - The definition of `actions` to perform
+ * @param {string} [params.timeout] - Request timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.updateAliases = function indicesUpdateAliasesApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1516,6 +2287,24 @@ IndicesApi.prototype.updateAliases = function indicesUpdateAliasesApi(params, op
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Upgrades to the current version of Lucene.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.wait_for_completion=false] - Specify whether the request should block until the all segments are upgraded
+ * @param {boolean} [params.only_ancient_segments] - If true, only ancient (an older Lucene major release) segments will be upgraded
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.upgrade = function indicesUpgradeApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -1537,6 +2326,32 @@ IndicesApi.prototype.upgrade = function indicesUpgradeApi(params, options, callb
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Allows a user to validate a potentially expensive query without executing it.
+ *
+ * @memberOf API-Index
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices
+ * @param {boolean} [params.explain] - Return detailed information about the error
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {string} [params.q] - Query in the Lucene query string syntax
+ * @param {string} [params.analyzer] - The analyzer to use for the query string
+ * @param {boolean} [params.analyze_wildcard=false] - Specify whether wildcard and prefix queries should be analyzed
+ * @param {string} [params.default_operator=OR] - The default operator for query string query (options: AND, OR)
+ * @param {string} [params.df] - The field to use as default where no field prefix is given in the query string
+ * @param {boolean} [params.lenient] - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+ * @param {boolean} [params.rewrite] - Provide a more detailed explanation showing the actual Lucene query that will be executed.
+ * @param {boolean} [params.all_shards] - Execute validation on all shards instead of one random shard per index
+ * @param {Object} [params.body] - The query definition specified with the Query DSL
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IndicesApi.prototype.validateQuery = function indicesValidateQueryApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/info.js
+++ b/api/api/info.js
@@ -36,6 +36,17 @@ const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = 
 const acceptedQuerystring = ['pretty', 'human', 'error_trace', 'source', 'filter_path'];
 const snakeCase = { errorTrace: 'error_trace', filterPath: 'filter_path' };
 
+/**
+ * Returns basic information about the cluster.
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function infoApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/ingest.js
+++ b/api/api/ingest.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Ingest */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'cluster_manager_timeout',
@@ -57,6 +59,22 @@ function IngestApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+/**
+ * Deletes a pipeline.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/ OpenSearch - Delete a pipeline}
+ *
+ * @memberOf API-Ingest
+ *
+ * @param {Object} params
+ * @param {string} params.id - Pipeline ID
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/ingest-apis/delete-ingest/#response Delete Pipeline Response}
+ */
 IngestApi.prototype.deletePipeline = function ingestDeletePipelineApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -84,6 +102,17 @@ IngestApi.prototype.deletePipeline = function ingestDeletePipelineApi(params, op
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns statistical information about geoip databases
+ *
+ * @memberOf API-Ingest
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IngestApi.prototype.geoIpStats = function ingestGeoIpStatsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -105,6 +134,22 @@ IngestApi.prototype.geoIpStats = function ingestGeoIpStatsApi(params, options, c
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns a pipeline.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/ OpenSearch - Get pipeline}
+ *
+ * @memberOf API-Ingest
+ *
+ * @param {Object} params
+ * @param {string} [params.id] - Comma separated list of pipeline ids. Wildcards supported
+ * @param {boolean} [params.summary=false] - Return pipelines without their definitions
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/ingest-apis/get-ingest/#response Get Pipeline Response}
+ */
 IngestApi.prototype.getPipeline = function ingestGetPipelineApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -131,6 +176,17 @@ IngestApi.prototype.getPipeline = function ingestGetPipelineApi(params, options,
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns a list of the built-in patterns.
+ *
+ * @memberOf API-Ingest
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IngestApi.prototype.processorGrok = function ingestProcessorGrokApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -152,6 +208,23 @@ IngestApi.prototype.processorGrok = function ingestProcessorGrokApi(params, opti
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Creates or updates a pipeline.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/ OpenSearch - Create/Update pipeline}
+ *
+ * @memberOf API-Ingest
+ *
+ * @param {Object} params
+ * @param {string} params.id - Pipeline ID
+ * @param {Object} params.body - Ingest definition
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/ingest-apis/create-update-ingest/#response Create/Update Pipeline Response}
+ */
 IngestApi.prototype.putPipeline = function ingestPutPipelineApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -183,6 +256,22 @@ IngestApi.prototype.putPipeline = function ingestPutPipelineApi(params, options,
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Allows to simulate a pipeline with example documents.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/ OpenSearch - Simulate Pipeline}
+ *
+ * @memberOf API-Ingest
+ *
+ * @param {Object} params
+ * @param {string} [params.id] - Pipeline ID
+ * @param {boolean} [params.verbose] - Verbose mode. Display data output for each processor in executed pipeline
+ * @param {Object} params.body - Simulate definition
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 IngestApi.prototype.simulate = function ingestSimulateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/mget.js
+++ b/api/api/mget.js
@@ -60,6 +60,30 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Retrieve multiple documents
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/multi-get/ OpenSearch - Multi-get Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {string} params.id - Document ID.
+ * @param {string} params.body - {@link https://opensearch.org/docs/2.4/api-reference/document-apis/multi-get/#request-body Multi-get Request Body}
+ * @param {string} [params.preference] - Specifies a preference of which shard to retrieve results from. Available options are '_local', which tells the operation to retrieve results from a locally allocated shard replica, and a custom string value assigned to a specific shard replica. By default, OpenSearch executes get document operations on random shards.
+ * @param {boolean} [params.realtime=true] - Specifies whether the operation should run in realtime. If false, the operation waits for the index to refresh to analyze the source to retrieve data, which makes the operation near-realtime.
+ * @param {boolean} [params.refresh=false] - If true, OpenSearch refreshes shards to make the get operation available to search results. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {string} [params.routing] - A value used to route the operation to a specific shard.
+ * @param {boolean} [params.stored_fields=false] - Whether the get operation should retrieve fields stored in the index.
+ * @param {string} [params._source=true] - Whether to include the '_source' field in the response body.
+ * @param {string} [params._source_excludes] - A comma-separated list of source fields to exclude in the query response.
+ * @param {string} [params._source_includes] - A comma-separated list of source fields to include in the query response.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/multi-get/#response Multi-get Response}
+ */
 function mgetApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/msearch.js
+++ b/api/api/msearch.js
@@ -59,6 +59,28 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Allows to execute several search operations in one request.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/multi-search/ OpenSearch - Multi-Search}
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names to use as default
+ * @param {Object} params.body - The request definitions (metadata-search request definition pairs), separated by newlines
+ * @param {string} [params.search_type] - Search operation type (options: query_then_fetch, dfs_query_then_fetch)
+ * @param {number} [params.max_concurrent_searches] - Controls the maximum number of concurrent searches the multi search api will execute
+ * @param {boolean} [params.typed_keys] - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+ * @param {number} [params.pre_filter_shard_size] - A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
+ * @param {number} [params.max_concurrent_shard_requests] - The number of concurrent shard requests each sub search executes concurrently per node. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
+ * @param {boolean} [params.rest_total_hits_as_int] - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+ * @param {boolean} [params.ccs_minimize_roundtrips] - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/multi-search/#response Multi-search Response}
+ */
 function msearchApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/msearch_template.js
+++ b/api/api/msearch_template.js
@@ -55,6 +55,25 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Allows to execute several search template operations in one request.
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names to use as default
+ * @param {Object} params.body - The request definitions (metadata-search request definition pairs), separated by newlines
+ * @param {string} [params.search_type] - Search operation type (options: query_then_fetch, dfs_query_then_fetch)
+ * @param {boolean} [params.typed_keys] - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+ * @param {number} [params.max_concurrent_searches] - Controls the maximum number of concurrent searches the multi search api will execute
+ * @param {boolean} [params.rest_total_hits_as_int] - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+ * @param {boolean} [params.ccs_minimize_roundtrips] - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function msearchTemplateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/nodes.js
+++ b/api/api/nodes.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Nodes */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'pretty',
@@ -155,6 +157,25 @@ NodesApi.prototype.getMeteringInfo = function nodesGetMeteringInfoApi(params, op
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about hot threads on each node in the cluster.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/ OpenSearch - Nodes Hot Threads}
+ * @memberOf API-Nodes
+ *
+ * @param {Object} params
+ * @param {string} [params.node_id] - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+ * @param {string} [params.interval] - The interval for the second sampling of threads
+ * @param {number} [params.snapshots] - Number of samples of thread stacktrace (default: 10)
+ * @param {number} [params.threads] - Specify the number of threads to provide information for (default: 3)
+ * @param {boolean} [params.ignore_idle_threads] - Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)
+ * @param {string} [params.type] - The type to sample (default: cpu) (options: cpu, wait, block)
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 NodesApi.prototype.hotThreads = function nodesHotThreadsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -206,6 +227,22 @@ NodesApi.prototype.hotThreads = function nodesHotThreadsApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about hot threads on each node in the cluster.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/ OpenSearch - Nodes Info}
+ * @memberOf API-Nodes
+ *
+ * @param {Object} params
+ * @param {string} [params.node_id] - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+ * @param {string} [params.metric] - A comma-separated list of metrics you wish returned. Leave empty to return all. (options: settings, os, process, jvm, thread_pool, transport, http, plugins, ingest)
+ * @param {boolean} [params.flat_settings] - Return settings in flat format (default: false)
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 NodesApi.prototype.info = function nodesInfoApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -244,6 +281,21 @@ NodesApi.prototype.info = function nodesInfoApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Reloads secure settings.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/ OpenSearch - Nodes Reload Security Settings}
+ * @memberOf API-Nodes
+ *
+ * @param {Object} params
+ * @param {string} [params.node_id] - A comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {Object} [params.body] - An object containing the password for the opensearch keystore
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 NodesApi.prototype.reloadSecureSettings = function nodesReloadSecureSettingsApi(
   params,
   options,
@@ -275,6 +327,30 @@ NodesApi.prototype.reloadSecureSettings = function nodesReloadSecureSettingsApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns statistical information about nodes in the cluster.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-stats/ OpenSearch - Nodes Stats}
+ * @memberOf API-Nodes
+ *
+ * @param {Object} params
+ * @param {string} [params.node_id] - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+ * @param {string} [params.metric] - Limit the information returned to the specified metrics (options: _all, breaker, fs, http, indices, jvm, os, process, thread_pool, transport, discovery, indexing_pressure)
+ * @param {string} [params.index_metric] - Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified. (options: _all, completion, docs, fielddata, query_cache, flush, get, indexing, merge, request_cache, refresh, search, segments, store, warmer, suggest)
+ * @param {string} [params.completion_fields] - A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
+ * @param {string} [params.fielddata_fields] - A comma-separated list of fields for `fielddata` index metric (supports wildcards)
+ * @param {string} [params.fields] - A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)
+ * @param {boolean} [params.groups] - A comma-separated list of search groups for `search` index metric
+ * @param {string} [params.level] - Return indices stats aggregated at index, node or shard level (options: indices, node, shards)
+ * @param {string} [params.types] - A comma-separated list of document types for the `indexing` index metric
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {boolean} [params.include_segment_file_sizes] - Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)
+ * @param {boolean} [params.include_unloaded_segments] - If set to true segment stats will include stats for segments that are not currently loaded into memory
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 NodesApi.prototype.stats = function nodesStatsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -339,6 +415,21 @@ NodesApi.prototype.stats = function nodesStatsApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns low-level information about REST actions usage on nodes.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/ OpenSearch - Nodes Usage}
+ * @memberOf API-Nodes
+ *
+ * @param {Object} params
+ * @param {string} [params.node_id] - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+ * @param {string} [params.metric] - Limit the information returned to the specified metrics (options: _all, rest_actions)
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 NodesApi.prototype.usage = function nodesUsageApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/ping.js
+++ b/api/api/ping.js
@@ -36,6 +36,17 @@ const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = 
 const acceptedQuerystring = ['pretty', 'human', 'error_trace', 'source', 'filter_path'];
 const snakeCase = { errorTrace: 'error_trace', filterPath: 'filter_path' };
 
+/**
+ * Returns whether the cluster is running.
+ *
+ * @memberOf API-Cluster
+ *
+ * @param {Object} params - (Unused)
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function pingApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/put_script.js
+++ b/api/api/put_script.js
@@ -51,6 +51,23 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Creates or updates a script.
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/script-apis/create-stored-script/ OpenSearch - Create or update stored script}
+ * @memberOf API-Script
+ *
+ * @param {Object} params
+ * @param {string} params.id - Stored script or search template name
+ * @param {string} params.body - The script
+ * @param {string} [params.context] - Context in which the script or search template is to run. To prevent errors, the API immediately compiles the script or template in this context.
+ * @param {string} [params.timeout=30s] - Explicit operation timeout
+ * @param {string} [params.cluster_manager_timeout] - Specify timeout for connection to cluster_manager
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function putScriptApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/rank_eval.js
+++ b/api/api/rank_eval.js
@@ -53,6 +53,25 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Allows to evaluate the quality of ranked search results over a set of typical search queries
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/rank-eval/ OpenSearch - Ranking evaluation}
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
+ * @param {Object} params.body - The ranking evaluation search definition, including search requests, document ratings and ranking metric definition
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {string} [params.search_type] - Search operation type (options: query_then_fetch, dfs_query_then_fetch)
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/rank-eval/#sample-response Ranking Evaluation Response}
+ */
 function rankEvalApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/reindex.js
+++ b/api/api/reindex.js
@@ -57,6 +57,28 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Copy all or a subset of your data from a source index into a destination index.
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/reindex/ OpenSearch - Reindex Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {Object} params.body The search definition using the Query DSL and the prototype for the index request.
+ * @param {boolean} [params.refresh=false] Should the affected indexes be refreshed?
+ * @param {string} [params.timeout=30s] Time each individual bulk request should wait for shards that are unavailable.
+ * @param {string} [params.wait_for_active_shards] Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+ * @param {boolean} [params.wait_for_completion=false] Should the request should block until the reindex is complete.
+ * @param {number} [params.requests_per_second=-1] The throttle to set on this request in sub-requests per second. -1 means no throttle.
+ * @param {string} [params.scroll=5m] Control how long to keep the search context alive
+ * @param {number|string} [params.slices=1] The number of slices this task should be divided into. 1 means the task isn't sliced into subtasks. Can be set to `auto`.
+ * @param {number} [params.max_docs] Maximum number of documents to process (default: all documents)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/reindex/#response Reindex Document Response}
+ */
 function reindexApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/reindex_rethrottle.js
+++ b/api/api/reindex_rethrottle.js
@@ -47,6 +47,20 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Changes the number of requests per second for a particular Reindex operation.
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.task_id - The task id to rethrottle
+ * @param {number} params.requests_per_second - The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function reindexRethrottleApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/render_search_template.js
+++ b/api/api/render_search_template.js
@@ -36,6 +36,20 @@ const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = 
 const acceptedQuerystring = ['pretty', 'human', 'error_trace', 'source', 'filter_path'];
 const snakeCase = { errorTrace: 'error_trace', filterPath: 'filter_path' };
 
+/**
+ * Allows to use the Mustache language to pre-render a search definition.
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} [params.id] - The id of the stored search template
+ * @param {Object} [params.body] - The search definition template and its params
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function renderSearchTemplateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/scripts_painless_execute.js
+++ b/api/api/scripts_painless_execute.js
@@ -36,6 +36,19 @@ const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = 
 const acceptedQuerystring = ['pretty', 'human', 'error_trace', 'source', 'filter_path'];
 const snakeCase = { errorTrace: 'error_trace', filterPath: 'filter_path' };
 
+/**
+ * Execute Painless script
+ * <br/> See also: {@link https://opensearch.org/docs/latest/api-reference/script-apis/exec-script/ OpenSearch - Execute Painless script}
+ * @memberOf API-Script
+ *
+ * @param {Object} params
+ * @param {string} params.body - The painless script
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function scriptsPainlessExecuteApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/scroll.js
+++ b/api/api/scroll.js
@@ -50,6 +50,23 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Allows to retrieve a large numbers of results from a single search request.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/scroll/ OpenSearch - Scroll }
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} [params.scroll_id] - The scroll ID *Deprecated*
+ * @param {string} [params.scroll] - Specify how long a consistent view of the index should be maintained for scrolled search
+ * @param {boolean} [params.rest_total_hits_as_int] - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+ * @param {Object} [params.body] - The scroll ID if not passed by URL or query parameter.
+ *
+ * @param {Object} [options] - Options for {@link Transport#request}
+ * @param {function} [callback] - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function scrollApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/search.js
+++ b/api/api/search.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Search */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'analyzer',
@@ -120,6 +122,64 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Allows to execute several search operations in one request.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/search/ OpenSearch - Search}
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
+ * @param {string} [params.analyzer] - The analyzer to use for the query string
+ * @param {boolean} [params.analyze_wildcard] - Specify whether wildcard and prefix queries should be analyzed (default: false)
+ * @param {boolean} [params.ccs_minimize_roundtrips] - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
+ * @param {string} [params.default_operator] - The default operator for query string query (AND or OR) (options: AND, OR)
+ * @param {string} [params.df] - The field to use as default where no field prefix is given in the query string
+ * @param {boolean} [params.explain] - Specify whether to return detailed information about score computation as part of a hit
+ * @param {string} [params.stored_fields] - A comma-separated list of stored fields to return as part of a hit
+ * @param {string} [params.docvalue_fields] - A comma-separated list of fields to return as the docvalue representation of a field for each hit
+ * @param {number} [params.from] - Starting offset (default: 0)
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.ignore_throttled] - Whether specified concrete, expanded or aliased indices should be ignored when throttled
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.lenient] - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+ * @param {string} [params.preference] - Specify the node or shard the operation should be performed on (default: random)
+ * @param {string} [params.q] - Query in the Lucene query string syntax
+ * @param {string} [params.routing] - A comma-separated list of specific routing values
+ * @param {string} [params.scroll] - Specify how long a consistent view of the index should be maintained for scrolled search
+ * @param {string} [params.search_type] - Search operation type (options: query_then_fetch, dfs_query_then_fetch)
+ * @param {number} [params.size] - Number of hits to return (default: 10)
+ * @param {string} [params.sort] - A comma-separated list of <field>:<direction> pairs
+ * @param {string} [params._source] - True or false to return the _source field or not, or a list of fields to return
+ * @param {string} [params._source_excludes] - A list of fields to exclude from the returned _source field
+ * @param {string} [params._source_includes] - A list of fields to extract and return from the _source field
+ * @param {number} [params.terminate_after] - The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
+ * @param {string} [params.stats] - Specific 'tag' of the request for logging and statistical purposes
+ * @param {string} [params.suggest_field] - Specify which field to use for suggestions
+ * @param {string} [params.suggest_mode] - Specify suggest mode (options: missing, popular, always)
+ * @param {number} [params.suggest_size] - How many suggestions to return in response
+ * @param {string} [params.suggest_text] - The source text for which the suggestions should be returned
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {boolean} [params.track_scores] - Whether to calculate and return scores even if they are not used for sorting
+ * @param {boolean} [params.track_total_hits] - Indicate if the number of documents that match the query should be tracked
+ * @param {boolean} [params.allow_partial_search_results] - Indicate if an error should be returned if there is a partial search failure or timeout
+ * @param {boolean} [params.typed_keys] - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+ * @param {boolean} [params.version] - Specify whether to return document version as part of a hit
+ * @param {boolean} [params.seq_no_primary_term] - Specify whether to return sequence number and primary term of the last modification of each hit
+ * @param {boolean} [params.request_cache] - Specify if request cache should be used for this request or not, defaults to index level setting
+ * @param {number} [params.batched_reduce_size] - The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
+ * @param {number} [params.max_concurrent_shard_requests] - The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
+ * @param {number} [params.pre_filter_shard_size] - A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
+ * @param {boolean} [params.rest_total_hits_as_int] - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+ * @param {string} [params.min_compatible_shard_node] - The minimum compatible version that all shards involved in search should have for this request to be successful
+ * @param {Object} [params.body] - The search definition using the Query DSL
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/latest/api-reference/search/#response-body Search Response}
+ */
 function searchApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/search_shards.js
+++ b/api/api/search_shards.js
@@ -54,6 +54,25 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Returns information about the indices and shards that a search request would be executed against.
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} [params.index] - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
+ * @param {string} [params.preference] - Specify the node or shard the operation should be performed on (default: random)
+ * @param {string} [params.routing] - Specific routing value
+ * @param {boolean} [params.local] - Return local information, do not retrieve the state from cluster_manager node (default: false)
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function searchShardsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/search_template.js
+++ b/api/api/search_template.js
@@ -66,6 +66,33 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Allows to use the Mustache language to pre-render a search definition.
+ *
+ * @memberOf API-Search
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
+ * @param {Object} params.body - The search definition template and its params
+ * @param {boolean} [params.ignore_unavailable] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.ignore_throttled] - Whether specified concrete, expanded or aliased indices should be ignored when throttled
+ * @param {boolean} [params.allow_no_indices] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+ * @param {string} [params.expand_wildcards] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {string} [params.preference] - Specify the node or shard the operation should be performed on (default: random)
+ * @param {string} [params.routing] - A comma-separated list of specific routing values
+ * @param {string} [params.scroll] - Specify how long a consistent view of the index should be maintained for scrolled search
+ * @param {string} [params.search_type] - Search operation type (options: query_then_fetch, dfs_query_then_fetch)
+ * @param {boolean} [params.explain] - Specify whether to return detailed information about score computation as part of a hit
+ * @param {boolean} [params.profile] - Specify whether to profile the query execution
+ * @param {boolean} [params.typed_keys] - Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+ * @param {boolean} [params.rest_total_hits_as_int] - Indicates whether hits.total should be rendered as an integer or an object in the rest search response
+ * @param {boolean} [params.ccs_minimize_roundtrips] - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function searchTemplateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/shutdown.js
+++ b/api/api/shutdown.js
@@ -41,6 +41,7 @@ function ShutdownApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+// TODO: Remove. Added in ES 7.15
 ShutdownApi.prototype.deleteNode = function shutdownDeleteNodeApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -68,6 +69,7 @@ ShutdownApi.prototype.deleteNode = function shutdownDeleteNodeApi(params, option
   return this.transport.request(request, options, callback);
 };
 
+// TODO: Remove. Added in ES 7.15
 ShutdownApi.prototype.getNode = function shutdownGetNodeApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -94,6 +96,7 @@ ShutdownApi.prototype.getNode = function shutdownGetNodeApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+// TODO: Remove. Added in ES 7.15
 ShutdownApi.prototype.putNode = function shutdownPutNodeApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/snapshot.js
+++ b/api/api/snapshot.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Snapshot */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'cluster_manager_timeout',
@@ -83,6 +85,21 @@ function SnapshotApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+/**
+ * Removes stale data from repository.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} params.repository - A repository name
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.cleanupRepository = function snapshotCleanupRepositoryApi(
   params,
   options,
@@ -114,6 +131,23 @@ SnapshotApi.prototype.cleanupRepository = function snapshotCleanupRepositoryApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Clones indices from one snapshot into another snapshot in the same repository.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} params.repository - A repository name
+ * @param {string} params.snapshot - The name of the snapshot to clone from
+ * @param {Object} params.body - The snapshot clone definition
+ * @param {string} [params.target_snapshot] - The name of the cloned snapshot to create
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.clone = function snapshotCloneApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -180,6 +214,23 @@ SnapshotApi.prototype.clone = function snapshotCloneApi(params, options, callbac
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Creates a snapshot in a repository.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} params.repository - A repository name
+ * @param {string} params.snapshot - A snapshot name
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.wait_for_completion] - Should this request wait until the operation has completed before returning
+ * @param {Object} [params.body] - The snapshot definition
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.create = function snapshotCreateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -218,6 +269,23 @@ SnapshotApi.prototype.create = function snapshotCreateApi(params, options, callb
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Creates a repository.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} params.repository - A repository name
+ * @param {Object} params.body - The repository definition
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {string} [params.timeout] - Explicit operation timeout
+ * @param {boolean} [params.verify] - Whether to verify the repository after creation
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.createRepository = function snapshotCreateRepositoryApi(
   params,
   options,
@@ -253,6 +321,22 @@ SnapshotApi.prototype.createRepository = function snapshotCreateRepositoryApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Deletes a snapshot.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} [params.repository] - A repository name
+ * @param {string} [params.snapshot] - A snapshot name
+ * @param {string} [params.master_timeout] - (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.delete = function snapshotDeleteApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -291,6 +375,22 @@ SnapshotApi.prototype.delete = function snapshotDeleteApi(params, options, callb
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Deletes a repository.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} [params.repository] - Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.
+ * @param {string} [params.master_timeout] - (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.deleteRepository = function snapshotDeleteRepositoryApi(
   params,
   options,
@@ -322,6 +422,26 @@ SnapshotApi.prototype.deleteRepository = function snapshotDeleteRepositoryApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about a snapshot.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} [params.repository] - A repository name
+ * @param {string} [params.snapshot] - A comma-separated list of snapshot names
+ * @param {string} [params.master_timeout] - (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.ignore_unavailable] - Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
+ * @param {boolean} [params.index_details] - Whether to include details of each index in the snapshot, if those details are available. Defaults to false.
+ * @param {boolean} [params.include_repository] - Whether to include the repository name in the snapshot info. Defaults to true.
+ * @param {boolean} [params.verbose] - Whether to show verbose snapshot info or only show the basic info found in the repository index blob
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.get = function snapshotGetApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -360,6 +480,21 @@ SnapshotApi.prototype.get = function snapshotGetApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about a snapshot.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} [params.repository] - A comma-separated list of repository names
+ * @param {string} [params.master_timeout] - (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.local] - Return local information, do not retrieve the state from cluster_manager node (default: false)
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.getRepository = function snapshotGetRepositoryApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -386,6 +521,30 @@ SnapshotApi.prototype.getRepository = function snapshotGetRepositoryApi(params, 
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Analyzes a repository for correctness and performance
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} [params.repository] - A repository name
+ * @param {number} [params.blob_count] - Number of blobs to create during the test. Defaults to 100.
+ * @param {number} [params.concurrency] - Number of operations to run concurrently during the test. Defaults to 10.
+ * @param {number} [params.read_node_count] - Number of nodes on which to read a blob after writing. Defaults to 10.
+ * @param {number} [params.early_read_node_count] - Number of nodes on which to perform an early read on a blob, i.e. before writing has completed. Early reads are rare actions so the 'rare_action_probability' parameter is also relevant. Defaults to 2.
+ * @param {number} [params.seed] - Seed for the random number generator used to create the test workload. Defaults to a random value.
+ * @param {number} [params.rare_action_probability] - Probability of taking a rare action such as an early read or an overwrite. Defaults to 0.02.
+ * @param {string} [params.max_blob_size] - Maximum size of a blob to create during the test, e.g '1gb' or '100mb'. Defaults to '10mb'.
+ * @param {string} [params.max_total_data_size] - Maximum total size of all blobs to create during the test, e.g '1tb' or '100gb'. Defaults to '1gb'.
+ * @param {string} [params.timeout] - Explicit operation timeout. Defaults to '30s'.
+ * @param {boolean} [params.detailed] - Whether to return detailed results or a summary. Defaults to 'false' so that only the summary is returned.
+ * @param {boolean} [params.rarely_abort_writes] - Whether to rarely abort writes before they complete. Defaults to 'true'.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.repositoryAnalyze = function snapshotRepositoryAnalyzeApi(
   params,
   options,
@@ -417,6 +576,24 @@ SnapshotApi.prototype.repositoryAnalyze = function snapshotRepositoryAnalyzeApi(
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Restores a snapshot.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} [params.repository] - A repository name
+ * @param {string} [params.snapshot] - A snapshot name
+ * @param {string} [params.master_timeout] - (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.wait_for_completion] - Should this request wait until the operation has completed before returning
+ * @param {Object} [params.body] - Details of what to restore
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.restore = function snapshotRestoreApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -462,6 +639,23 @@ SnapshotApi.prototype.restore = function snapshotRestoreApi(params, options, cal
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about the status of a snapshot.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} [params.repository] - A repository name
+ * @param {string} [params.snapshot] - A comma-separated list of snapshot names
+ * @param {string} [params.master_timeout] - (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {boolean} [params.ignore_unavailable] - Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.status = function snapshotStatusApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -505,6 +699,22 @@ SnapshotApi.prototype.status = function snapshotStatusApi(params, options, callb
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Verifies a repository.
+ *
+ * @memberOf API-Snapshot
+ *
+ * @param {Object} params
+ * @param {string} [params.repository] - A repository name
+ * @param {string} [params.master_timeout] - (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
+ * @param {string} [params.cluster_manager_timeout] - Explicit operation timeout for connection to cluster_manager node
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 SnapshotApi.prototype.verifyRepository = function snapshotVerifyRepositoryApi(
   params,
   options,

--- a/api/api/tasks.js
+++ b/api/api/tasks.js
@@ -32,6 +32,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-Tasks */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'nodes',
@@ -60,6 +62,24 @@ function TasksApi(transport, ConfigurationError) {
   this[kConfigurationError] = ConfigurationError;
 }
 
+/**
+ * Cancels a task, if it can be cancelled through an API.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling OpenSearch - Task Cancelling}
+ *
+ * @memberOf API-Tasks
+ *
+ * @param {Object} params
+ * @param {string} [params.task_id] - Cancel the task with specified task id (node_id:task_number)
+ * @param {string} [params.nodes] - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+ * @param {string} [params.actions] - A comma-separated list of actions that should be cancelled. Leave empty to cancel all.
+ * @param {string} [params.parent_task_id] - Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.
+ * @param {boolean} [params.wait_for_completion] - Should the request block until the cancellation of the task and its descendant tasks is completed. Defaults to false
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 TasksApi.prototype.cancel = function tasksCancelApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -86,6 +106,22 @@ TasksApi.prototype.cancel = function tasksCancelApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns information about a task.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/tasks OpenSearch - Tasks}
+ *
+ * @memberOf API-Tasks
+ *
+ * @param {Object} params
+ * @param {string} [params.task_id] - Return the task with specified id (node_id:task_number)
+ * @param {boolean} [params.wait_for_completion] - Wait for the matching tasks to complete (default: false)
+ * @param {string} [params.timeout] - Explicit operation timeoutompletion] - Should the request block until the cancellation of the task and its descendant tasks is completed. Defaults to false
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 TasksApi.prototype.get = function tasksGetApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 
@@ -113,6 +149,26 @@ TasksApi.prototype.get = function tasksGetApi(params, options, callback) {
   return this.transport.request(request, options, callback);
 };
 
+/**
+ * Returns a list of tasks.
+ * <br/> See Also: {@link https://opensearch.org/docs/latest/api-reference/tasks OpenSearch - Tasks}
+ *
+ * @memberOf API-Tasks
+ *
+ * @param {Object} params
+ * @param {string} [params.nodes] - A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+ * @param {string} [params.actions] - A comma-separated list of actions that should be returned. Leave empty to return all.
+ * @param {boolean} [params.detailed] - Return detailed task information (default: false)
+ * @param {string} [params.parent_task_id] - Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.
+ * @param {boolean} [params.wait_for_completion] - Wait for the matching tasks to complete (default: false)
+ * @param {string} [params.group_by] - Group tasks by nodes or parent/child relationships (options: nodes, parents, none)
+ * @param {string} [params.timeout] - Explicit operation timeout
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 TasksApi.prototype.list = function tasksListApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/terms_enum.js
+++ b/api/api/terms_enum.js
@@ -36,6 +36,7 @@ const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = 
 const acceptedQuerystring = ['pretty', 'human', 'error_trace', 'source', 'filter_path'];
 const snakeCase = { errorTrace: 'error_trace', filterPath: 'filter_path' };
 
+// TODO: Remove. Added in ES 7.14
 function termsEnumApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/termvectors.js
+++ b/api/api/termvectors.js
@@ -59,6 +59,32 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Returns information and statistics about terms in the fields of a particular document.
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - The index in which the document resides.
+ * @param {string} [params.id] - The id of the document, when not specified a doc param should be supplied.
+ * @param {boolean} [params.term_statistics] - Specifies if total term frequency and document frequency should be returned.
+ * @param {boolean} [params.field_statistics] - Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.
+ * @param {string} [params.fields] - A comma-separated list of fields to return.
+ * @param {boolean} [params.offsets] - Specifies if term offsets should be returned.
+ * @param {boolean} [params.positions] - Specifies if term positions should be returned.
+ * @param {boolean} [params.payloads] - Specifies if term payloads should be returned.
+ * @param {string} [params.preference] - Specify the node or shard the operation should be performed on (default: random).
+ * @param {string} [params.routing] - Specific routing value.
+ * @param {boolean} [params.realtime] - Specifies if request is real-time as opposed to near-real-time (default: true).
+ * @param {number} [params.version] - Explicit version number for concurrency control
+ * @param {string} [params.version_type] - Specific version type (options: internal, external, external_gte, force)
+ * @param {Object} [params.body] - Define parameters and or supply a document to get termvectors for. See documentation.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function termvectorsApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/update.js
+++ b/api/api/update.js
@@ -68,6 +68,34 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Update an existing document
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/update-document/ OpenSearch - Update Document}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - Name of the index.
+ * @param {string} params.id - A unique identifier to attach to the document.
+ * @param {Object} params.body - The request definition requires either `script` or partial `doc`.
+ * @param {number} [params.if_seq_no] - Only perform the update operation if the document has the specified sequence number.
+ * @param {number} [params.if_primary_term] - Only perform the update operation if the document has the specified primary term.
+ * @param {string} [params.lang=painless] - Language of the script.
+ * @param {string} [params.routing] - Value used to assign the index operation to a specific shard.
+ * @param {string} [params._source=true] - Whether to include the '_source' field in the response body.
+ * @param {string} [params._source_excludes] - A comma-separated list of source fields to exclude in the query response.
+ * @param {string} [params._source_includes] - A comma-separated list of source fields to include in the query response.
+ * @param {string} [params.refresh=false] - If true, OpenSearch refreshes shards to make the operation visible to searching. Valid options are 'true', 'false', and 'wait_for', which tells OpenSearch to wait for a refresh before executing the operation.
+ * @param {number} [params.retry_on_conflict=0] - The amount of times OpenSearch should retry the operation if there’s a document conflict.
+ * @param {string} [params.timeout=1m] - How long to wait for a response from the cluster.
+ * @param {string} [params.wait_for_active_shards] - The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
+ * @param {boolean} [params.require_alias=false] - Specifies whether the target index must be an index alias.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/update-document/#response Update Response}
+ */
 function updateApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/update_by_query.js
+++ b/api/api/update_by_query.js
@@ -101,6 +101,56 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Run a script to update all documents that match the query.
+ * <br/> See Also: {@link https://opensearch.org/docs/2.4/api-reference/document-apis/update-by-query/ OpenSearch - Update by query}
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.index - A comma-separated list of index names to search; use '_all' or empty string to perform the operation on all indices
+ * @param {Object} [params.body] - The search definition using the Query DSL
+ * @param {string} [params.analyzer] - The analyzer to use for the query string
+ * @param {boolean} [params.analyze_wildcard=false] - Specify whether wildcard and prefix queries should be analyzed (default: false)
+ * @param {string} [params.default_operator=OR] - The default operator for query string query (options: AND, OR)
+ * @param {string} [params.df] - The field to use as default where no field prefix is given in the query string
+ * @param {number} [params.from=0] - Starting offset
+ * @param {boolean} [params.ignore_unavailable=false] - Whether specified concrete indices should be ignored when unavailable (missing or closed)
+ * @param {boolean} [params.allow_no_indices=true] - Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes '_all' string or when no indices have been specified)
+ * @param {string} [params.conflicts=abort] - What to do when the update by query hits version conflicts? (options: abort, proceed)
+ * @param {string} [params.expand_wildcards=open] - Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+ * @param {boolean} [params.lenient=false] - Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
+ * @param {string} [params.pipeline] - Ingest pipeline to set on index requests made by this action. (default: none)
+ * @param {string} [params.preference] - Specify the node or shard the operation should be performed on (default: random)
+ * @param {string} [params.q] - Query in the Lucene query string syntax
+ * @param {string} [params.routing] - A comma-separated list of specific routing values
+ * @param {string} [params.scroll] - Specify how long a consistent view of the index should be maintained for scrolled search
+ * @param {string} [params.search_type=query_then_fetch] - Search operation type (options: query_then_fetch, dfs_query_then_fetch)
+ * @param {string} [params.search_timeout] - Explicit timeout for each search request. Defaults to no timeout.
+ * @param {number} [params.size] - Deprecated, please use 'max_docs' instead
+ * @param {number} [params.max_docs] - Maximum number of documents to process (default: all documents)
+ * @param {string} [params.sort] - A comma-separated list of <field>:<direction> pairs
+ * @param {string} [params._source] - True or false to return the _source field or not, or a list of fields to return
+ * @param {string} [params._source_excludes] - A list of fields to exclude from the returned _source field
+ * @param {string} [params._source_includes] - A list of fields to extract and return from the _source field
+ * @param {number} [params.terminate_after] - The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
+ * @param {string} [params.stats] - Specific 'tag' of the request for logging and statistical purposes
+ * @param {boolean} [params.version] - Specify whether to return document version as part of a hit
+ * @param {boolean} [params.version_type] - Should the document increment the version number (internal) on hit or not (reindex)
+ * @param {boolean} [params.request_cache] - Specify if request cache should be used for this request or not, defaults to index level setting
+ * @param {boolean} [params.refresh=false] - Should the affected indexes be refreshed?
+ * @param {string} [params.timeout] - Time each individual bulk request should wait for shards that are unavailable.
+ * @param {string} [params.wait_for_active_shards=1] - Sets the number of shard copies that must be active before proceeding with the update by query operation. 1 means the primary shard only. Set to 'all' for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+ * @param {number} [params.scroll_size=1000] - Size on the scroll request powering the update by query
+ * @param {boolean} [params.wait_for_completion=true] - Should the request should block until the update by query operation is complete.
+ * @param {number} [params.requests_per_second=-1] - The throttle to set on this request in sub-requests per second. -1 means no throttle.
+ * @param {string} [params.slices=1] - The number of slices this task should be divided into. 1 means the task isn't sliced into subtasks. Can be set to 'auto'.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*} {@link https://opensearch.org/docs/2.4/api-reference/document-apis/update-by-query/#response Update by query Response}
+ */
 function updateByQueryApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/api/api/update_by_query_rethrottle.js
+++ b/api/api/update_by_query_rethrottle.js
@@ -47,6 +47,20 @@ const snakeCase = {
   filterPath: 'filter_path',
 };
 
+/**
+ * Changes the number of requests per second for a particular Update By Query operation.
+ *
+ * @memberOf API-Document
+ *
+ * @param {Object} params
+ * @param {string} params.task_id - The task id to rethrottle
+ * @param {number} params.requests_per_second - The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.
+ *
+ * @param {Object} options - Options for {@link Transport#request}
+ * @param {function} callback - Callback that handles errors and response
+ *
+ * @returns {{abort: function(), then: function(), catch: function()}|Promise<never>|*}
+ */
 function updateByQueryRethrottleApi(params, options, callback) {
   [params, options, callback] = normalizeArguments(params, options, callback);
 

--- a/lib/Serializer.js
+++ b/lib/Serializer.js
@@ -90,7 +90,7 @@ class Serializer {
     const keys = Object.keys(object);
     for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
-      // OpenSearch will complain for keys without a value
+      // OpenSearch will complain about keys without a value
       if (object[key] === undefined) {
         delete object[key];
       } else if (Array.isArray(object[key]) === true) {

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -56,6 +56,7 @@ const HEAP_SIZE_LIMIT = require('v8').getHeapStatistics().heap_size_limit;
 const kCompatibleCheck = Symbol('compatible check');
 const kApiVersioning = Symbol('api versioning');
 
+/** Default Transport Layer */
 class Transport {
   constructor(opts) {
     if (typeof opts.compression === 'string' && opts.compression !== 'gzip') {
@@ -110,6 +111,27 @@ class Transport {
     }
   }
 
+  /**
+   * @param {Object} params
+   * @param {string} params.method - HTTP Method (e.g. HEAD, GET, POST...)
+   * @param {string} params.path - Relative URL path
+   * @param {Object | string} [params.body] - Body of a standard request.
+   * @param {Object[] | string} [params.bulkBody] - Body of a bulk request.
+   * @param {Object[] | string} [params.querystring] - Querystring params.
+   *
+   * @param {Object} options
+   * @param {number} [options.id] - Request ID
+   * @param {Object} [options.context] - Object used for observability
+   * @param {number} [options.maxRetries] - Max number of retries
+   * @param {false | 'gzip'} [options.compression] - Request body compression, if any
+   * @param {boolean} [options.asStream] - Whether to emit the response as stream
+   * @param {number[]} [options.ignore] - Response's Error Status Codes to ignore
+   * @param {Object} [options.headers] - Request headers
+   * @param {Object | string} [options.querystring] - Request's query string
+   * @param {number} [options.requestTimeout] - Max request timeout in milliseconds
+   *
+   * @param {function} callback - Callback that handles errors and response
+   */
   request(params, options, callback) {
     options = options || {};
     if (typeof options === 'function') {
@@ -386,7 +408,7 @@ class Transport {
         // if the statusCode is 502/3/4 we should run our retry strategy
         // and mark the connection as dead
         this.connectionPool.markDead(meta.connection);
-        // retry logic (we shoukd not retry on "429 - Too Many Requests")
+        // retry logic (we should not retry on "429 - Too Many Requests")
         if (meta.attempts < maxRetries && result.statusCode !== 429) {
           meta.attempts++;
           debug(`Retrying request, there are still ${maxRetries - meta.attempts} attempts`, params);

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "fast-deep-equal": "^3.1.3",
     "into-stream": "^6.0.0",
     "js-yaml": "^4.1.0",
+    "jsdoc": "^4.0.0",
     "license-checker": "^25.0.1",
     "minimist": "^1.2.5",
     "node-fetch": "^3.2.10",


### PR DESCRIPTION
### Description
This change added jsdoc and a workflow to generate and publish documentation to gh_pages. It also includes documentation for Transport#request and api/bulk. More documentation will also be added incrementally in the subsequent PRs.


### Issues Resolved
closes https://github.com/opensearch-project/opensearch-js/issues/335

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
