### PR TITLE
Fixed missing namespace for API-PIT endpoints

### DIFF
--- a/api/api/create_pit.js
+++ b/api/api/create_pit.js
@@ -13,6 +13,8 @@
 /* eslint camelcase: 0 */
 /* eslint no-unused-vars: 0 */
 
+/** @namespace API-PIT */
+
 const { handleError, snakeCaseKeys, normalizeArguments, kConfigurationError } = require('../utils');
 const acceptedQuerystring = [
   'allow_partial_pit_creation',


### PR DESCRIPTION
Signed-off-by: Theo Truong <theotr@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
