### PR TITLE
Add missing types for AwsSigv4SignerOptions.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix mutability of connection headers ([#291](https://github.com/opensearch-project/opensearch-js/issues/291))
+- Added missing types for AwsSigv4SignerOptions.service ([#374](https://github.com/opensearch-project/opensearch-js/pull/374))
 
 [2.1]: https://github.com/opensearch-project/opensearch-js/releases/tag/2.1.0
 [Unreleased]: https://github.com/opensearch-project/opensearch-js/compare/2.1...HEAD

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -19,6 +19,7 @@ import { OpenSearchClientError } from '../errors';
 interface AwsSigv4SignerOptions {
   getCredentials?: () => Promise<Credentials>;
   region: string;
+  service: 'es' | 'aoss';
 }
 
 interface AwsSigv4SignerResponse {

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -19,7 +19,6 @@ import { OpenSearchClientError } from '../errors';
 interface AwsSigv4SignerOptions {
   getCredentials?: () => Promise<Credentials>;
   region: string;
-  service: 'es' | 'aoss';
 }
 
 interface AwsSigv4SignerResponse {


### PR DESCRIPTION
### Description
2.2.0 added support for AOSS, but the types weren't updated.

### Issues Resolved
Fixes #356
Fixes #366

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
