### PR TITLE
Add missing types for AwsSigv4SignerOptions.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Added missing types for AwsSigv4SignerOptions.service ([#377](https://github.com/opensearch-project/opensearch-js/pull/377))
+
+
 ### Security
 - [CVE-2022-25912] Bumps simple-git from 3.4.0 to 3.15.0 ([#341](https://github.com/opensearch-project/opensearch-js/pull/341))
 

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -19,6 +19,7 @@ import { OpenSearchClientError } from '../errors';
 interface AwsSigv4SignerOptions {
   getCredentials?: () => Promise<Credentials>;
   region: string;
+  service: 'es' | 'aoss';
 }
 
 interface AwsSigv4SignerResponse {

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -19,7 +19,7 @@ import { OpenSearchClientError } from '../errors';
 interface AwsSigv4SignerOptions {
   getCredentials?: () => Promise<Credentials>;
   region: string;
-  service: 'es' | 'aoss';
+  service?: 'es' | 'aoss';
 }
 
 interface AwsSigv4SignerResponse {


### PR DESCRIPTION
Signed-off-by: magoz <apps@magoz.is>

### Description
2.2.0 added support for AOSS, but the types weren't updated.

### Issues Resolved
Fixes #356
Fixes #366

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
