### PR TITLE
 Allow fields in BulkOperation to be optional

### DIFF
--- a/api/types.d.ts
+++ b/api/types.d.ts
@@ -40,12 +40,12 @@ export interface BulkIndexOperation extends BulkOperation { }
 export interface BulkIndexResponseItem extends BulkResponseItemBase { }
 
 export interface BulkOperation {
-  _id: Id;
-  _index: IndexName;
-  retry_on_conflict: integer;
-  routing: Routing;
-  version: VersionNumber;
-  version_type: VersionType;
+  _id?: Id;
+  _index?: IndexName;
+  retry_on_conflict?: integer;
+  routing?: Routing;
+  version?: VersionNumber;
+  version_type?: VersionType;
 }
 
 export interface BulkOperationContainer {


### PR DESCRIPTION
### Description

This should change the `BulkOperation` type to more closely match the OpenSearch API. It makes the API types for requests slightly less restrictive and easier to use in Typescript.

From my limited understanding of the parser is that not all fields are required for bulk requests. From the BulkRequestParserTests in the project there are a few examples showing this behavior, where only `_id` provided: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/test/java/org/opensearch/action/bulk/BulkRequestParserTests.java#L119

From the (1.x and 2.x) API docs too, it doesn't look like all fields in `BulkOperation` type definition are required. 

https://opensearch.org/docs/1.2/opensearch/rest-api/document-apis/bulk/#request-body
https://opensearch.org/docs/2.5/api-reference/document-apis/bulk/#request-body
> All actions support the same metadata: `_index`, `_id`, and `_require_alias`. If you don’t provide an ID, OpenSearch generates one automatically, which can make it challenging to update the document at a later time.

If this was intentional to have all fields required, I'm curious to know why?


This might be more of an "issue" but the change appeared too straightforward for me to do that. 

Thanks!

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Cameron Durham <camdurha@amazon.com>
