### PR TITLE
Add 2PR approval to release workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - id: get_data
+        run: |
+          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+          echo "version=$(cat package.json | jq .version | tr -d "\"")" >> $GITHUB_OUTPUT
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_data.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: 'Release opensearch-js : ${{ steps.get_data.outputs.version }}'
+          issue-body: "Please approve or deny the release of opensearch-js. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
+          exclude-workflow-initiator-as-approver: true
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
### Description
This change retrieves the codeowner's list from .github/codeowners file and adds them as approvers for releasing opensearch-dsl-py.
Here is a sample issue that is created when this workflow runs: https://github.com/gaiksaya/opensearch-js/issues/1
Once approved, the workflow continues to run as usual.
**_Note: This approval duration is subject to the broader 72 hours timeout for a workflow._**

### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/3111

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
