### PR TITLE
Fix deprecated folder mapping "./" in the "exports" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Added missing types for AwsSigv4SignerOptions.service ([#377](https://github.com/opensearch-project/opensearch-js/pull/377))
+- Fixed deprecated folder mapping "./" in the "exports" field module resolution ([#416](https://github.com/opensearch-project/opensearch-js/pull/416))
+
 ### Security
 - [CVE-2022-25912] Bumps simple-git from 3.4.0 to 3.15.0 ([#341](https://github.com/opensearch-project/opensearch-js/pull/341))
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "import": "./index.mjs"
     },
     "./aws": "./lib/aws/index.js",
-    "./": "./"
+    "./*": "./*"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
### Description
This will fix a deprecation warning throw by node v16.14.0

(node:13221) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at (...)/node_modules/@opensearch-project/opensearch/package.json.

### Issues Resolved
closes #343

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
