### PR TITLE
[CCI] fix: pass required `data` argument to SerializationError class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Documented all API methods ([#335](https://github.com/opensearch-project/opensearch-js/issues/335))
 - Added point in time APIs ([#348](https://github.com/opensearch-project/opensearch-js/pull/348))
 - Added support for Amazon OpenSearch Serverless ([#356](https://github.com/opensearch-project/opensearch-js/issues/356))
-
+- Added an overload `constructor` for `SerializationError` interface ([#419](https://github.com/opensearch-project/opensearch-js/pull/419))
 ### Dependencies
 - Bumps `xmlbuilder2` from 2.4.1 to 3.0.2
 - Bumps `minimatch` from 3.0.4 to 3.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Documented all API methods ([#335](https://github.com/opensearch-project/opensearch-js/issues/335))
 - Added point in time APIs ([#348](https://github.com/opensearch-project/opensearch-js/pull/348))
 - Added support for Amazon OpenSearch Serverless ([#356](https://github.com/opensearch-project/opensearch-js/issues/356))
-- Added an overload `constructor` for `SerializationError` interface ([#419](https://github.com/opensearch-project/opensearch-js/pull/419))
+- Added required `array` argument when invoking `SerializationError` ([#419](https://github.com/opensearch-project/opensearch-js/pull/419))
 ### Dependencies
 - Bumps `xmlbuilder2` from 2.4.1 to 3.0.2
 - Bumps `minimatch` from 3.0.4 to 3.1.2

--- a/lib/Serializer.js
+++ b/lib/Serializer.js
@@ -69,7 +69,7 @@ class Serializer {
   ndserialize(array) {
     debug('ndserialize', array);
     if (Array.isArray(array) === false) {
-      throw new SerializationError('The argument provided is not an array');
+      throw new SerializationError('The argument provided is not an array', array);
     }
     let ndjson = '';
     for (let i = 0, len = array.length; i < len; i++) {

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -69,7 +69,6 @@ export declare class SerializationError extends OpenSearchClientError {
   message: string;
   data: any;
   constructor(message: string, data: any);
-  constructor(message: string);
 }
 
 export declare class DeserializationError extends OpenSearchClientError {

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -69,6 +69,7 @@ export declare class SerializationError extends OpenSearchClientError {
   message: string;
   data: any;
   constructor(message: string, data: any);
+  constructor(message: string);
 }
 
 export declare class DeserializationError extends OpenSearchClientError {


### PR DESCRIPTION
### Description
Pass required `data` argument to `SerializationError` class
 
### Issues Resolved
Closes: #418 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
