### PR TITLE
[CCI] Refactor: Remove unnecessary `data` argument when invoking `OpenSearchClientError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Documented all API methods ([#335](https://github.com/opensearch-project/opensearch-js/issues/335))
 - Added point in time APIs ([#348](https://github.com/opensearch-project/opensearch-js/pull/348))
 - Added support for Amazon OpenSearch Serverless ([#356](https://github.com/opensearch-project/opensearch-js/issues/356))
+- Removed unnecessary `data` argument when invoking `OpenSearchClientError` ([#420](https://github.com/opensearch-project/opensearch-js/issues/420))
 
 ### Dependencies
 - Bumps `xmlbuilder2` from 2.4.1 to 3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Documented all API methods ([#335](https://github.com/opensearch-project/opensearch-js/issues/335))
 - Added point in time APIs ([#348](https://github.com/opensearch-project/opensearch-js/pull/348))
 - Added support for Amazon OpenSearch Serverless ([#356](https://github.com/opensearch-project/opensearch-js/issues/356))
-- Removed unnecessary `data` argument when invoking `OpenSearchClientError` ([#420](https://github.com/opensearch-project/opensearch-js/issues/420))
+- Removed unnecessary `data` argument when invoking `OpenSearchClientError` ([#421](https://github.com/opensearch-project/opensearch-js/pull/421))
 
 ### Dependencies
 - Bumps `xmlbuilder2` from 2.4.1 to 3.0.2

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -69,7 +69,6 @@ export declare class SerializationError extends OpenSearchClientError {
   message: string;
   data: any;
   constructor(message: string, data: any);
-  constructor(message: string);
 }
 
 export declare class DeserializationError extends OpenSearchClientError {

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -69,6 +69,7 @@ export declare class SerializationError extends OpenSearchClientError {
   message: string;
   data: any;
   constructor(message: string, data: any);
+  constructor(message: string);
 }
 
 export declare class DeserializationError extends OpenSearchClientError {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -70,7 +70,7 @@ class NoLivingConnectionsError extends OpenSearchClientError {
 
 class SerializationError extends OpenSearchClientError {
   constructor(message, data) {
-    super(message, data);
+    super(message);
     Error.captureStackTrace(this, SerializationError);
     this.name = 'SerializationError';
     this.message = message || 'Serialization Error';
@@ -80,7 +80,7 @@ class SerializationError extends OpenSearchClientError {
 
 class DeserializationError extends OpenSearchClientError {
   constructor(message, data) {
-    super(message, data);
+    super(message);
     Error.captureStackTrace(this, DeserializationError);
     this.name = 'DeserializationError';
     this.message = message || 'Deserialization Error';


### PR DESCRIPTION
### Description
Removes the unnecessary `data` argument when invoking the OpenSearchClientError superclass

### Issues Resolved
Closes #420

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
