### PR TITLE
[CCI] Remove waitCluster in Integration Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Add release details to releasing.md ([319](https://github.com/opensearch-project/opensearch-js/pull/319))
 - Added Amazon OpenSearch Serverless in user_guide ([#372](https://github.com/opensearch-project/opensearch-js/issues/372))
+- Remove waitCluster in Integration Tests ([#422](https://github.com/opensearch-project/opensearch-js/issues/422))
 ### Dependencies
 - Bumps `aws4` from 1.11.0 to 1.12.0
 - Bumps `minimist` from 1.2.6 to 1.2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Add release details to releasing.md ([319](https://github.com/opensearch-project/opensearch-js/pull/319))
 - Added Amazon OpenSearch Serverless in user_guide ([#372](https://github.com/opensearch-project/opensearch-js/issues/372))
-- Remove waitCluster in Integration Tests ([#422](https://github.com/opensearch-project/opensearch-js/issues/422))
 ### Dependencies
 - Bumps `aws4` from 1.11.0 to 1.12.0
 - Bumps `minimist` from 1.2.6 to 1.2.8
@@ -25,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Make fields in `BulkOperation` optional to match OpenSearch Bulk API requirements ([#378](https://github.com/opensearch-project/opensearch-js/pull/378))
 ### Deprecated
 ### Removed
+- Remove waitCluster in Integration Tests ([#422](https://github.com/opensearch-project/opensearch-js/issues/422))
 ### Fixed
 - Added missing types for AwsSigv4SignerOptions.service ([#377](https://github.com/opensearch-project/opensearch-js/pull/377))
 ### Security

--- a/test/integration/helpers-secure/search.test.js
+++ b/test/integration/helpers-secure/search.test.js
@@ -14,7 +14,7 @@ const { createReadStream } = require('fs');
 const { join } = require('path');
 const split = require('split2');
 const { test, beforeEach, afterEach } = require('tap');
-const { waitCluster } = require('../../utils');
+
 const { Client } = require('../../..');
 
 const INDEX = `test-helpers-${process.pid}`;
@@ -30,7 +30,7 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-  await waitCluster(client);
+
   await client.indices.create({ index: INDEX });
   const stream = createReadStream(join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson'));
   const result = await client.helpers.bulk({

--- a/test/integration/helpers-secure/search.test.js
+++ b/test/integration/helpers-secure/search.test.js
@@ -30,7 +30,6 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-
   await client.indices.create({ index: INDEX });
   const stream = createReadStream(join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson'));
   const result = await client.helpers.bulk({

--- a/test/integration/helpers/bulk.test.js
+++ b/test/integration/helpers/bulk.test.js
@@ -33,7 +33,6 @@ const { createReadStream } = require('fs');
 const { join } = require('path');
 const split = require('split2');
 const { test, beforeEach, afterEach } = require('tap');
-const { waitCluster } = require('../../utils');
 const { Client } = require('../../../');
 
 const datasetPath = join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson');
@@ -43,7 +42,7 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-  await waitCluster(client);
+
   await client.indices.create({ index: INDEX });
 });
 

--- a/test/integration/helpers/bulk.test.js
+++ b/test/integration/helpers/bulk.test.js
@@ -42,7 +42,6 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-
   await client.indices.create({ index: INDEX });
 });
 

--- a/test/integration/helpers/msearch.test.js
+++ b/test/integration/helpers/msearch.test.js
@@ -33,7 +33,7 @@ const { createReadStream } = require('fs');
 const { join } = require('path');
 const split = require('split2');
 const { test, beforeEach, afterEach } = require('tap');
-const { waitCluster } = require('../../utils');
+
 const { Client, errors } = require('../../../');
 
 const INDEX = `test-helpers-${process.pid}`;
@@ -42,7 +42,7 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-  await waitCluster(client);
+
   await client.indices.create({ index: INDEX });
   const stream = createReadStream(join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson'));
   const result = await client.helpers.bulk({

--- a/test/integration/helpers/msearch.test.js
+++ b/test/integration/helpers/msearch.test.js
@@ -42,7 +42,6 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-
   await client.indices.create({ index: INDEX });
   const stream = createReadStream(join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson'));
   const result = await client.helpers.bulk({

--- a/test/integration/helpers/scroll.test.js
+++ b/test/integration/helpers/scroll.test.js
@@ -33,7 +33,7 @@ const { createReadStream } = require('fs');
 const { join } = require('path');
 const split = require('split2');
 const { test, beforeEach, afterEach } = require('tap');
-const { waitCluster } = require('../../utils');
+
 const { Client } = require('../../../');
 
 const INDEX = `test-helpers-${process.pid}`;
@@ -42,7 +42,7 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-  await waitCluster(client);
+
   await client.indices.create({ index: INDEX });
   const stream = createReadStream(join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson'));
   const result = await client.helpers.bulk({

--- a/test/integration/helpers/scroll.test.js
+++ b/test/integration/helpers/scroll.test.js
@@ -42,7 +42,6 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-
   await client.indices.create({ index: INDEX });
   const stream = createReadStream(join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson'));
   const result = await client.helpers.bulk({

--- a/test/integration/helpers/search.test.js
+++ b/test/integration/helpers/search.test.js
@@ -33,7 +33,7 @@ const { createReadStream } = require('fs');
 const { join } = require('path');
 const split = require('split2');
 const { test, beforeEach, afterEach } = require('tap');
-const { waitCluster } = require('../../utils');
+
 const { Client } = require('../../../');
 
 const INDEX = `test-helpers-${process.pid}`;
@@ -42,7 +42,7 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-  await waitCluster(client);
+
   await client.indices.create({ index: INDEX });
   const stream = createReadStream(join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson'));
   const result = await client.helpers.bulk({

--- a/test/integration/helpers/search.test.js
+++ b/test/integration/helpers/search.test.js
@@ -42,7 +42,6 @@ const client = new Client({
 });
 
 beforeEach(async () => {
-
   await client.indices.create({ index: INDEX });
   const stream = createReadStream(join(__dirname, '..', '..', 'fixtures', 'stackoverflow.ndjson'));
   const result = await client.helpers.bulk({

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -81,7 +81,6 @@ function runner(opts = {}) {
   });
 }
 
-
 async function start({ client }) {
   log('Waiting for OpenSearch');
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -81,22 +81,9 @@ function runner(opts = {}) {
   });
 }
 
-async function waitCluster(client, times = 0) {
-  try {
-    await client.cluster.health({ waitForStatus: 'green', timeout: '50s' });
-  } catch (err) {
-    if (++times < 10) {
-      await sleep(5000);
-      return waitCluster(client, times);
-    }
-    console.error(err);
-    process.exit(1);
-  }
-}
 
 async function start({ client }) {
   log('Waiting for OpenSearch');
-  await waitCluster(client);
 
   const { body } = await client.info();
   const { number: version, build_hash: hash } = body.version;

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -40,7 +40,6 @@ const yaml = require('js-yaml');
 const ms = require('ms');
 const { Client } = require('../../index');
 const build = require('./test-runner');
-const { sleep } = require('./helper');
 const createJunitReporter = require('./reporter');
 const downloadArtifacts = require('../../scripts/download-artifacts');
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -37,8 +37,6 @@ const buildProxy = require('./buildProxy');
 const connection = require('./MockConnection');
 const { Client } = require('../../');
 
-
-
 function skipCompatibleCheck(client) {
   const tSymbol = Object.getOwnPropertySymbols(client.transport || client).filter(
     (symbol) => symbol.description === 'compatible check'

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -37,20 +37,7 @@ const buildProxy = require('./buildProxy');
 const connection = require('./MockConnection');
 const { Client } = require('../../');
 
-async function waitCluster(client, waitForStatus = 'green', timeout = '50s', times = 0) {
-  if (!client) {
-    throw new Error('waitCluster helper: missing client instance');
-  }
-  try {
-    await client.cluster.health({ waitForStatus, timeout });
-  } catch (err) {
-    if (++times < 10) {
-      await sleep(5000);
-      return waitCluster(client, waitForStatus, timeout, times);
-    }
-    throw err;
-  }
-}
+
 
 function skipCompatibleCheck(client) {
   const tSymbol = Object.getOwnPropertySymbols(client.transport || client).filter(
@@ -71,7 +58,6 @@ module.exports = {
   buildCluster,
   buildProxy,
   connection,
-  waitCluster,
   skipCompatibleCheck,
   Client: NoCompatibleCheckClient,
 };

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -29,8 +29,6 @@
 
 'use strict';
 
-const { promisify } = require('util');
-const sleep = promisify(setTimeout);
 const buildServer = require('./buildServer');
 const buildCluster = require('./buildCluster');
 const buildProxy = require('./buildProxy');


### PR DESCRIPTION
### Description
Removing waitCluster in Integration Tests due to it's redundancy and complication of running integration tests locally
### Issues Resolved
closes #422  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
