### PR TITLE
[CCI] Backport fix: remove `data` arg in 2.x

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -71,7 +71,7 @@ class NoLivingConnectionsError extends OpenSearchClientError {
 
 class SerializationError extends OpenSearchClientError {
   constructor(message, data) {
-    super(message, data);
+    super(message);
     Error.captureStackTrace(this, SerializationError);
     this.name = 'SerializationError';
     this.message = message || 'Serialization Error';
@@ -81,7 +81,7 @@ class SerializationError extends OpenSearchClientError {
 
 class DeserializationError extends OpenSearchClientError {
   constructor(message, data) {
-    super(message, data);
+    super(message);
     Error.captureStackTrace(this, DeserializationError);
     this.name = 'DeserializationError';
     this.message = message || 'Deserialization Error';


### PR DESCRIPTION
### Description
Backport to 2.x

### Issues Resolved
Closes #420 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
