### PR TITLE
[CCI] Fix2 deprecation warnings in `bulk.test.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove test artifacts from gh_pages workflow ([#335](https://github.com/opensearch-project/opensearch-js/issues/335))
 - Make fields in `BulkOperation` optional to match OpenSearch Bulk API requirements ([#378](https://github.com/opensearch-project/opensearch-js/pull/378))
 ### Deprecated
+- Remove deprecation warnings in bulk.test.js ([#434](https://github.com/opensearch-project/opensearch-js/issues/434))
 ### Removed
 - Remove waitCluster in Integration Tests ([#422](https://github.com/opensearch-project/opensearch-js/issues/422))
 ### Fixed

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -1051,11 +1051,11 @@ test('bulk update', (t) => {
     let count = 0;
     const MockConnection = connection.buildMockConnection({
       onRequest(params) {
-        t.strictEqual(params.path, '/_bulk');
+        t.equal(params.path, '/_bulk');
         t.match(params.headers, { 'content-type': 'application/x-ndjson' });
         const [action, payload] = params.body.split('\n');
-        t.deepEqual(JSON.parse(action), { update: { _index: 'test', _id: count } });
-        t.deepEqual(JSON.parse(payload), { doc: dataset[count++], doc_as_upsert: true });
+        t.same(JSON.parse(action), { update: { _index: 'test', _id: count } });
+        t.same(JSON.parse(payload), { doc: dataset[count++], doc_as_upsert: true });
         return { body: { errors: false, items: [{ update: { result: 'noop' } }] } };
       },
     });
@@ -1465,13 +1465,13 @@ test('Flush interval', (t) => {
     let count = 0;
     const MockConnection = connection.buildMockConnection({
       onRequest(params) {
-        t.strictEqual(params.path, '/_bulk');
+        t.equal(params.path, '/_bulk');
         t.match(params.headers, {
           'content-type': 'application/x-ndjson',
         });
         const [action, payload] = params.body.split('\n');
-        t.deepEqual(JSON.parse(action), { index: { _index: 'test' } });
-        t.deepEqual(JSON.parse(payload), dataset[count++]);
+        t.same(JSON.parse(action), { index: { _index: 'test' } });
+        t.same(JSON.parse(payload), dataset[count++]);
         return { body: { errors: false, items: [{}] } };
       },
     });


### PR DESCRIPTION
### Description
Removed deprecation warnings in `bulk.test.js` by replacing `strictEqual()` to `equal()` and `deepEqual()` to `same()`

### Issues Resolved
Closes [434](https://github.com/opensearch-project/opensearch-js/issues/434).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
