### PR TITLE
[CCI] `BaseConnectionPool` missing implementation of `markAlive` and `markDead` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Added missing types for AwsSigv4SignerOptions.service ([#377](https://github.com/opensearch-project/opensearch-js/pull/377))
 - Fixed deprecated folder mapping "./" in the "exports" field module resolution ([#416](https://github.com/opensearch-project/opensearch-js/pull/416))
+- Fixed `BaseConnectionPool` markAlive and markDead and their tests ([#449](https://github.com/opensearch-project/opensearch-js/pull/449))
 
 ### Security
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -297,3 +297,26 @@ if (connection !== null) {
   client.connectionPool.markAlive(connection)
 }
 ```
+## Mark connection as `dead`
+```javascript
+console.log('Marking connection as dead:');
+
+var connection = client.connectionPool.getConnection()
+// or var connection = client.connectionPool.connections[0]
+
+if (connection !== null) {
+  client.connectionPool.markDead(connection)
+}
+```
+
+## Mark connection as `alive`
+```javascript
+console.log('Marking connection as alive:');
+
+var connection = client.connectionPool.getConnection()
+// or var connection = client.connectionPool.connections[0]
+
+if (connection !== null) {
+  client.connectionPool.markAlive(connection)
+}
+```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -274,3 +274,26 @@ if (connection !== null) {
   client.connectionPool.markAlive(connection)
 }
 ```
+## Mark connection as `dead`
+```javascript
+console.log('Marking connection as dead:');
+
+var connection = client.connectionPool.getConnection()
+// or var connection = client.connectionPool.connections[0]
+
+if (connection !== null) {
+  client.connectionPool.markDead(connection)
+}
+```
+
+## Mark connection as `alive`
+```javascript
+console.log('Marking connection as alive:');
+
+var connection = client.connectionPool.getConnection()
+// or var connection = client.connectionPool.connections[0]
+
+if (connection !== null) {
+  client.connectionPool.markAlive(connection)
+}
+```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -250,3 +250,27 @@ var response = await client.deleteAllPits();
 
 console.log(response.body);
 ```
+
+## Mark connection as `dead`
+```javascript
+console.log('Marking connection as dead:');
+
+var connection = client.connectionPool.getConnection()
+// or var connection = client.connectionPool.connections[0]
+
+if (connection !== null) {
+  client.connectionPool.markDead(connection)
+}
+```
+
+## Mark connection as `alive`
+```javascript
+console.log('Marking connection as alive:');
+
+var connection = client.connectionPool.getConnection()
+// or var connection = client.connectionPool.connections[0]
+
+if (connection !== null) {
+  client.connectionPool.markAlive(connection)
+}
+```

--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -52,11 +52,13 @@ class BaseConnectionPool {
     throw new Error('getConnection must be implemented');
   }
 
-  markAlive() {
+  markAlive(connection) {
+    connection.status = Connection.statuses.ALIVE;
     return this;
   }
 
-  markDead() {
+  markDead(connection) {
+    connection.status = Connection.statuses.DEAD;
     return this;
   }
 

--- a/test/unit/base-connection-pool.test.js
+++ b/test/unit/base-connection-pool.test.js
@@ -80,6 +80,17 @@ test('API', (t) => {
     t.end();
   });
 
+  t.test('call markDead twice', (t) => {
+    const pool = new BaseConnectionPool({ Connection, sniffEnabled: true });
+    const href = 'http://localhost:9200/';
+    let connection = pool.addConnection(href);
+    t.same(pool.markDead(connection), pool);
+    t.same(pool.markDead(connection), pool);
+    connection = pool.connections.find((c) => c.id === href);
+    t.equal(connection.status, Connection.statuses.DEAD);
+    t.end();
+  });
+
   t.test('markAlive', (t) => {
     const pool = new BaseConnectionPool({ Connection, sniffEnabled: true });
     const href = 'http://localhost:9200/';
@@ -87,6 +98,31 @@ test('API', (t) => {
     t.same(pool.markAlive(connection), pool);
     connection = pool.connections.find((c) => c.id === href);
     t.equal(connection.status, Connection.statuses.ALIVE);
+    t.end();
+  });
+
+  t.test('call markAlive twice', (t) => {
+    const pool = new BaseConnectionPool({ Connection, sniffEnabled: true });
+    const href = 'http://localhost:9200/';
+    let connection = pool.addConnection(href);
+    t.same(pool.markAlive(connection), pool);
+    t.same(pool.markAlive(connection), pool);
+    connection = pool.connections.find((c) => c.id === href);
+    t.equal(connection.status, Connection.statuses.ALIVE);
+    t.end();
+  });
+
+  t.test('call markDead and markAlive', (t) => {
+    const pool = new BaseConnectionPool({ Connection, sniffEnabled: true });
+    const href = 'http://localhost:9200/';
+    let connection = pool.addConnection(href);
+    t.same(pool.markDead(connection), pool);
+    t.equal(connection.status, Connection.statuses.DEAD);
+    t.same(pool.markAlive(connection), pool);
+    t.equal(connection.status, Connection.statuses.ALIVE);
+    connection = pool.connections.find((c) => c.id === href);
+    t.equal(connection.status, Connection.statuses.ALIVE);
+    t.not(connection.status, Connection.statuses.DEAD);
     t.end();
   });
 

--- a/test/unit/base-connection-pool.test.js
+++ b/test/unit/base-connection-pool.test.js
@@ -76,7 +76,7 @@ test('API', (t) => {
     let connection = pool.addConnection(href);
     t.same(pool.markDead(connection), pool);
     connection = pool.connections.find((c) => c.id === href);
-    t.equal(connection.status, Connection.statuses.ALIVE);
+    t.equal(connection.status, Connection.statuses.DEAD);
     t.end();
   });
 


### PR DESCRIPTION
### Description

Implement `BaseConnectionPool` `markDead` and `markAlive` methods
Fix unit test

### Issues Resolved
Closes #429 

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
