### PR TITLE
[CCI] Update developerGuide regarding yarn troubleshoot steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Make fields in `BulkOperation` optional to match OpenSearch Bulk API requirements ([#378](https://github.com/opensearch-project/opensearch-js/pull/378))
 - Remove guidance on using npm and switch completely to yarn in developer_guide ([#439](https://github.com/opensearch-project/opensearch-js/issues/435))
 - Change coverage, compatability, integration, integration with unreleased Open Search, node ci, bundler tests not to run on documentation change ([441](https://github.com/opensearch-project/opensearch-js/pull/441))
-
+- Change the Windows yarn installation troubleshoot steps ([455](https://github.com/opensearch-project/opensearch-js/issues/455))
 ### Deprecated
 
 - Remove deprecation warnings in bulk.test.js ([#434](https://github.com/opensearch-project/opensearch-js/issues/434))

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -61,7 +61,7 @@ If the problem persists, you can try to open Windows PowerShell as an administra
 ```
 Set-ExecutionPolicy -ExecutionPolicy Unrestricted
 ```
-It is recommended to change the execution policy to RemoteSigned or Undefined.
+
 ### Using ESLint
 
 To do a ESLint check on the project, run:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -51,13 +51,17 @@ There might be an issue on Windows OS:
 ```
 yarn. ps1 cannot be loaded because running scripts is disabled on this system
 ```
-If it occurs, open Windows PowerShell as an administrator and run:
+If this occurs, open Windows PowerShell and run:
 ```
-Set-ExecutionPolicy unrestricted
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
-Then type `Y`
+Agree to the changes.
 Now you can run `yarn install`
-
+If the problem persists, you can try to open Windows PowerShell as an administrator and run:
+```
+Set-ExecutionPolicy -ExecutionPolicy Unrestricted
+```
+It is recommended to change the execution policy to RemoteSigned or Undefined.
 ### Using ESLint
 
 To do a ESLint check on the project, run:


### PR DESCRIPTION
### Description

Currently the Developer's Guide solution to Windows not letting you running scripts on client PCs is to set the policy to Unrestricted. Running the yarn install script should be possible even with the execution policy set to RemoteSigned, and this will also prevent users from opening themselves up to potential malicious unsigned scripts that they can run.
Besides this, by scoping the poilcy change to current user in the guide, there's no need to run PowerShell with administrator privileges (especially relevant when user doesn't have access to them)

### Issues Resolved

Closes #455 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
