### PR TITLE
Draft: feat: implement markDead and markAlive in Connection [CCI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unnecessary `data` argument when invoking `OpenSearchClientError` ([#421](https://github.com/opensearch-project/opensearch-js/pull/421))
 - Fixed typos in `ConnectionPool` ([#427](https://github.com/opensearch-project/opensearch-js/pull/427))
 - Added the solution for the possible error during yarn installation on Windows OS ([#435](https://github.com/opensearch-project/opensearch-js/issues/435))
+- Added `markAlive` and `markDead` methods to `Connection` ([#477](https://github.com/opensearch-project/opensearch-js/pull/477))
 
 ### Dependencies
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -11,6 +11,7 @@
   - [Delete the document](#delete-the-document)
   - [Delete the index](#delete-the-index)
   - [Empty all Pool Connections](#empty-all-pool-connections)
+  - [Change Connection Status](#change-connection-status)
 
 ## Initializing a Client
 
@@ -264,4 +265,14 @@ pool.empty();
 pool.empty(() => {
   // Do something after emptying the pool
 });
+```
+
+## Change Connection Status
+
+```javascript
+var connection = new Connection({
+  url: new URL('http://localhost:9200'),
+});
+connection.markDead();
+connection.markAlive();
 ```

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -204,6 +204,17 @@ class Connection {
     this._status = status;
   }
 
+  markAlive() {
+    this._status = Connection.statuses.ALIVE;
+    this.deadCount = 0;
+    this.resurrectTimeout = 0;
+  }
+
+  markDead() {
+    this._status = Connection.statuses.DEAD;
+    this.deadCount++;
+  }
+
   buildRequestObject(params) {
     const url = this.url;
     const request = {

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -1116,3 +1116,28 @@ test('Abort with a slow body', (t) => {
 
   setImmediate(() => request.abort());
 });
+
+test('Connection markDead', (t) => {
+  t.plan(2);
+
+  const connection = new Connection({
+    url: new URL('http://localhost:9200'),
+  });
+
+  connection.markDead();
+  t.equal(connection.status, Connection.statuses.DEAD);
+  t.equal(connection.deadCount, 1);
+});
+
+test('Connection markAlive', (t) => {
+  t.plan(2);
+
+  const connection = new Connection({
+    url: new URL('http://localhost:9200'),
+  });
+
+  connection.markDead();
+  connection.markAlive();
+  t.equal(connection.status, Connection.statuses.ALIVE);
+  t.equal(connection.deadCount, 0);
+});


### PR DESCRIPTION
### Description

Implements `markDead` and `markAlive` in the `Connection` class
 
### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
