### PR TITLE
[CCI] Connection `request` method callback

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -134,7 +134,7 @@ class Connection {
       request.once('error', () => {}); // we need to catch the request aborted error
       debug('Request aborted', params);
       this._openRequests--;
-      callback(new RequestAbortedError(), null);
+      callback(new RequestAbortedError('Request aborted'), null);
     };
 
     request.on('response', onResponse);

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -51,7 +51,7 @@ export declare class ConnectionError<
   name: string;
   message: string;
   meta: ApiResponse<TResponse, TContext>;
-  constructor(message: string, meta: ApiResponse);
+  constructor(message: string, meta?: ApiResponse);
 }
 
 export declare class NoLivingConnectionsError<
@@ -104,7 +104,7 @@ export declare class RequestAbortedError<
   name: string;
   message: string;
   meta: ApiResponse<TResponse, TContext>;
-  constructor(message: string, meta: ApiResponse);
+  constructor(message: string, meta?: ApiResponse);
 }
 
 export declare class NotCompatibleError<


### PR DESCRIPTION
### Description
The `request` method of Connection invokes a callback, but required arguments of `err` are not provided.


### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
