### PR TITLE
[CCI] feat: add missing createConnection type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unnecessary `data` argument when invoking `OpenSearchClientError` ([#421](https://github.com/opensearch-project/opensearch-js/pull/421))
 - Fixed typos in `ConnectionPool` ([#427](https://github.com/opensearch-project/opensearch-js/pull/427))
 - Added the solution for the possible error during yarn installation on Windows OS ([#435](https://github.com/opensearch-project/opensearch-js/issues/435))
+- Added missing `createConnection` method type definition in `BaseConnectionPool` )([#490](https://github.com/opensearch-project/opensearch-js/pull/490))
 
 ### Dependencies
 

--- a/lib/pool/index.d.ts
+++ b/lib/pool/index.d.ts
@@ -115,6 +115,13 @@ declare class BaseConnectionPool {
    * @returns {object|null} connection
    */
   getConnection(opts?: getConnectionOptions): Connection | null;
+
+  /**
+   * Creates a new connection instance.
+   * @param {object|string} opts
+   * @returns {Connection}
+   */
+  createConnection(opts: ConnectionOptions | string): Connection;
   /**
    * Adds a new connection to the pool.
    *

--- a/test/types/connection-pool.test-d.ts
+++ b/test/types/connection-pool.test-d.ts
@@ -60,6 +60,7 @@ import { ConnectionOptions } from '../../lib/Connection';
       now: Date.now(),
     })
   );
+  expectType<Connection>(pool.createConnection({ url: new URL('url') }));
   expectType<Connection>(pool.addConnection({ url: new URL('url') }));
   expectType<BaseConnectionPool>(pool.removeConnection(new Connection()));
   expectType<void>(pool.empty());


### PR DESCRIPTION
### Description

Added missing `createConnection` method TS definition in `BaseConnectionPool` and a test

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
