### PR TITLE
Add upgrading NPM to all workflows running older Node.js versions

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -31,9 +31,20 @@ jobs:
           make cluster.clean cluster.opensearch.build cluster.opensearch.start
 
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
+
+      # NPM started understanding yarn.lock file starting from v7
+      - name: Update NPM
+        shell: bash
+        run: |
+          export NPM_VERSION=$(npm -v)
+          export IS_NPM_SUITABLE=$(node -p "parseInt(process.env.NPM_ROOT, 10) >= 7")
+          if [ "$IS_NPM_SUITABLE" == "false" ]; then
+            echo "NPM needs upgrading!"
+            npm i npm@7 -g
+          fi
 
       - name: Install
         run: |

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -50,7 +50,7 @@ jobs:
           make cluster.clean cluster.opensearch.build cluster.opensearch.start
 
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,9 +23,20 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      # NPM started understanding yarn.lock file starting from v7
+      - name: Update NPM
+        shell: bash
+        run: |
+          export NPM_VERSION=$(npm -v)
+          export IS_NPM_SUITABLE=$(node -p "parseInt(process.env.NPM_ROOT, 10) >= 7")
+          if [ "$IS_NPM_SUITABLE" == "false" ]; then
+            echo "NPM needs upgrading!"
+            npm i npm@7 -g
+          fi
 
       - name: Install
         run: |

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -9,7 +9,7 @@ jobs:
     name: Update gh-pages with docs
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           ruby-version: 16.x
       - name: Install Tools

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -34,9 +34,20 @@ jobs:
           make cluster.clean cluster.opensearch.build cluster.opensearch.start
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      # NPM started understanding yarn.lock file starting from v7
+      - name: Update NPM
+        shell: bash
+        run: |
+          export NPM_VERSION=$(npm -v)
+          export IS_NPM_SUITABLE=$(node -p "parseInt(process.env.NPM_ROOT, 10) >= 7")
+          if [ "$IS_NPM_SUITABLE" == "false" ]; then
+            echo "NPM needs upgrading!"
+            npm i npm@7 -g
+          fi
 
       - name: Install
         run: |
@@ -52,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -70,9 +81,20 @@ jobs:
           make cluster.clean cluster.opensearch.build cluster.opensearch.start
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      # NPM started understanding yarn.lock file starting from v7
+      - name: Update NPM
+        shell: bash
+        run: |
+          export NPM_VERSION=$(npm -v)
+          export IS_NPM_SUITABLE=$(node -p "parseInt(process.env.NPM_ROOT, 10) >= 7")
+          if [ "$IS_NPM_SUITABLE" == "false" ]; then
+            echo "NPM needs upgrading!"
+            npm i npm@7 -g
+          fi
 
       - name: Install
         run: |

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -15,9 +15,20 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      # NPM started understanding yarn.lock file starting from v7
+      - name: Update NPM
+        shell: bash
+        run: |
+          export NPM_VERSION=$(npm -v)
+          export IS_NPM_SUITABLE=$(node -p "parseInt(process.env.NPM_ROOT, 10) >= 7")
+          if [ "$IS_NPM_SUITABLE" == "false" ]; then
+            echo "NPM needs upgrading!"
+            npm i npm@7 -g
+          fi
 
       - name: Install
         run: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,16 +18,27 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      # NPM started understanding yarn.lock file starting from v7
+      - name: Update NPM
+        shell: bash
+        run: |
+          export NPM_VERSION=$(npm -v)
+          export IS_NPM_SUITABLE=$(node -p "parseInt(process.env.NPM_ROOT, 10) >= 7")
+          if [ "$IS_NPM_SUITABLE" == "false" ]; then
+            echo "NPM needs upgrading!"
+            npm i npm@7 -g
+          fi
 
       - name: Install
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `node-fetch` from 3.2.10 to 3.3.1
 ### Changed
 - Implemented Docker Image caching for `integration-unreleased` workflow ([#387](https://github.com/opensearch-project/opensearch-js/issues/387))
+- Add upgrading NPM to all workflows running older Node.js versions ([#545](https://github.com/opensearch-project/opensearch-js/issues/545))
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
Add upgrading NPM to all workflows running older Node.js versions

Also
* Add compatibility checks for latest versions of Node.js
* Bump `actions/setup-node` to v3

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [X] Commits are signed per the DCO using --signoff
- [X] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
