### PR TITLE
Upgrade and secure the backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,17 @@ jobs:
       contents: write
       pull-requests: write
     name: Backport
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     steps:
       - name: GitHub App token
         id: github_app_token
@@ -19,10 +30,14 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          # opensearch-trigger-bot installation ID
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v1.1.4
+        uses: VachaShah/backport@v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
-          branch_name: backport/backport-${{ github.event.number }}
+          head_template: backport/backport-<%= number %>-to-<%= base %>
+          files_to_skip: "CHANGELOG.md"
+          labels_template: "<%= JSON.stringify([...labels, 'autocut']) %>"
+          failure_labels: "failed backport"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Implemented Docker Image caching for `integration-unreleased` workflow ([#387](https://github.com/opensearch-project/opensearch-js/issues/387))
 - Add upgrading NPM to all workflows running older Node.js versions ([#545](https://github.com/opensearch-project/opensearch-js/issues/545))
+- Upgrade and secure the backport workflow ([#547](https://github.com/opensearch-project/opensearch-js/issues/547))
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
Upgrade to the latest backport action and configure the proper labeling and ignoring logic.

Also:
* secure the backport workflow to run only when a PR is merged or relabeled after close.

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [X] Commits are signed per the DCO using --signoff
- [X] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
