### PR TITLE
Fix wrong documentation for file `serach.md` regarding `search_after` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix wrong documentation for file serach.md regarding `search_after` param ([#584](https://github.com/opensearch-project/opensearch-js/pull/584))
 ### Security
 
 ## [2.3.0]

--- a/guides/search.md
+++ b/guides/search.md
@@ -120,24 +120,27 @@ const page_1 = await client.search({
   size: 2,
   body: search_body
 });
+const documents_1 = page_1.body.hits.hits;
 
 const page_2 = await client.search({
   index: 'movies',
   size: 2,
   body: {
     ...search_body,
-    search_after: page_1[page_1.length - 1].sort
+    search_after: documents_1[documents_1.length - 1].sort
   }
 });
+const documents_2 = page_2.body.hits.hits;
 
 const page_3 = await client.search({
   index: 'movies',
   size: 2,
   body: {
     ...search_body,
-    search_after: page_2[page_2.length - 1].sort
+    search_after: documents_2[documents_2.length - 1].sort
   }
-})
+});
+const documents_3 = page_3.body.hits.hits;
 ```
 ### Pagination with scroll
 When retrieving large amounts of non-real-time data, you can use the `scroll` parameter to paginate through the search results.
@@ -182,25 +185,28 @@ const page_1 = await client.search({
   size: 2,
   body: pit_search_body
 });
-console.log(page_1.body.hits.hits);
+const documents_1 = page_1.body.hits.hits;
+console.log(documents_1);
 
 const page_2 = await client.search({
   size: 2,
   body: {
     ...pit_search_body,
-    search_after: page_1[page_1.length - 1].sort  
+    search_after: documents_1[documents_1.length - 1].sort  
   }
 });
-console.log(page_2.body.hits.hits);
+const documents_2 = page_2.body.hits.hits;
+console.log(documents_2);
 
 const page_3 = await client.search({
   size: 2,
   body: {
     ...pit_search_body,
-    search_after: page2[page_2.length-1].sort
+    search_after: documents_2[documents_2.length-1].sort
   }
 });
-console.log(page_3.body.hits.hits);
+const documents_3 = page_3.body.hits.hits;
+console.log(documents_3);
 
 /** Print out the titles of the first 3 pages of results */
 console.log(page_1.map(hit => hit._source.title));


### PR DESCRIPTION
### Description

I was following instructions in `search.md` in order to use `search()` functions, especially with `search_after` param. And found out given example doesn't work. I made some changes so that people can make use of the code snippet in `search.md` without logical error.

### Issues Resolved
No issue resolved

### Check List

- [X] New functionality includes testing. -- no need to test
  - [ ] All tests pass
- [X] Linter check was successfull - `yarn run lint` doesn't show any errors
- [X] Commits are signed per the DCO using --signoff
- [X] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
