### PR TITLE
Refactor BaseConnectionPool empty method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `eslint-config-prettier` from 8.8.0 to 9.0.0
 ### Changed
 - Make handling of long numerals an option that is disabled by default ([#557](https://github.com/opensearch-project/opensearch-js/pull/557))
+- Refactor BaseConnectionPool empty method so that callback will always get called even when there is no connection ([#585](https://github.com/opensearch-project/opensearch-js/pull/585)) 
 ### Deprecated
 ### Removed
 ### Fixed

--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -150,13 +150,14 @@ class BaseConnectionPool {
     let openConnections = this.size;
     this.connections.forEach((connection) => {
       connection.close(() => {
-        if (--openConnections === 0) {
-          this.connections = [];
-          this.size = this.connections.length;
-          callback();
-        }
+        openConnections--;
       });
     });
+    if (openConnections === 0) {
+      this.connections = [];
+      this.size = this.connections.length;
+      callback();
+    }
   }
 
   /**

--- a/test/unit/base-connection-pool.test.js
+++ b/test/unit/base-connection-pool.test.js
@@ -156,6 +156,14 @@ test('API', (t) => {
     t.end();
   });
 
+  t.test('empty with no connection', (t) => {
+    const pool = new BaseConnectionPool({ Connection });
+    t.equal(pool.connections.length, 0);
+    pool.empty();
+    t.equal(pool.size, 0);
+    t.end();
+  });
+
   t.test('urlToHost', (t) => {
     const pool = new BaseConnectionPool({ Connection });
     const url = 'http://localhost:9200';


### PR DESCRIPTION
### Description

ConnectionPool.empty() never calls callback when there is no connection. Refactor empty method so that callback will get always called.

### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Linter check was successfull - `yarn run lint` doesn't show any errors
- [X] Commits are signed per the DCO using --signoff
- [X] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
