### PR TITLE
[Update] delete index guide with ignore_unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Updated `guides/index_lifecycle.md` to provide example of `ignore_unavailable: true` while deleting indices.
+- Updated `guides/index_lifecycle.md` to provide example of `ignore_unavailable: true` while deleting indices. ([665](https://github.com/opensearch-project/opensearch-js/pull/665))
 ### Dependencies
 - Bumps `@types/node` from 20.9.0 to 20.10.3
 - Bumps `eslint` from 8.54.0 to 8.55.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Updated `guides/index_lifecycle.md` to provide example of `ignore_unavailable: true` while deleting indices.
 ### Dependencies
 - Bumps `@types/node` from 20.9.0 to 20.10.3
 - Bumps `eslint` from 8.54.0 to 8.55.0

--- a/guides/index_lifecycle.md
+++ b/guides/index_lifecycle.md
@@ -141,7 +141,7 @@ We can also delete multiple indices at once:
 ```javascript
 client.indices.delete({index: ['movies', 'paintings', 'burner'], ignore_unavailable: true,})
 ```
-Notice that we are passing `ignore_unavailable: true,` to the request. This tells the client to ignore throwing error and deleting the index if it doesn't exist. Without it, the above `delete` request will throw an error because the `movies` index has already been deleted in the previous example.
+Notice that we are passing `ignore_unavailable: true` to the request. This tells the client to ignore throwing error and deleting the index if it doesn't exist. Without it, the above `delete` request will throw an error because the `movies` index has already been deleted in the previous example.
 
 ## Cleanup
 

--- a/guides/index_lifecycle.md
+++ b/guides/index_lifecycle.md
@@ -139,9 +139,9 @@ client.indices.delete({index: 'movies'})
 We can also delete multiple indices at once:
 
 ```javascript
-client.indices.delete({index: ['movies', 'paintings', 'burner'], ignore: 404})
+client.indices.delete({index: ['movies', 'paintings', 'burner'], ignore_unavailable: true,})
 ```
-Notice that we are passing `ignore: 404` to the request. This tells the client to ignore the `404` error if the index doesn't exist for deletion. Without it, the above `delete` request will throw an error because the `movies` index has already been deleted in the previous example.
+Notice that we are passing `ignore_unavailable: true,` to the request. This tells the client to ignore throwing error and deleting the index if it doesn't exist. Without it, the above `delete` request will throw an error because the `movies` index has already been deleted in the previous example.
 
 ## Cleanup
 


### PR DESCRIPTION
### Description

Update **Delete an Index** in index_lifecycle.md with `ignore_unavailable: true`

### Issues Resolved

#658

### Check List

- [X] Commits are signed per the DCO using --signoff
- [X]  Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
