### PR TITLE
Pass in initialAdminPassword

### DIFF
--- a/.ci/opensearch/Dockerfile.opensearch
+++ b/.ci/opensearch/Dockerfile.opensearch
@@ -9,6 +9,6 @@ ARG SECURE_INTEGRATION
 HEALTHCHECK --start-period=20s --interval=5s --retries=2 --timeout=1s \
   CMD if [ "$SECURE_INTEGRATION" != "true" ]; \
   then curl --fail localhost:9200/_cat/health; \
-  else curl --fail -k https:/localhost:9200/_cat/health -u admin:admin; fi
+  else curl --fail -k https:/localhost:9200/_cat/health -u admin:myStrongPassword123!; fi
 
 RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then $opensearch_path/bin/opensearch-plugin remove opensearch-security; fi

--- a/.ci/opensearch/docker-compose.yml
+++ b/.ci/opensearch/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - SECURE_INTEGRATION=${SECURE_INTEGRATION:-false}
-      - initialAdminPassword=myStrongPassword123!
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
     ports:
       - '9200:9200'
     user: opensearch

--- a/.ci/opensearch/docker-compose.yml
+++ b/.ci/opensearch/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - SECURE_INTEGRATION=${SECURE_INTEGRATION:-false}
+      - initialAdminPassword=myStrongPassword123!
     ports:
       - '9200:9200'
     user: opensearch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `@aws-sdk/types` from 3.451.0 to 3.468.0
 - Bumps `prettier` from 3.1.0 to 3.1.1
 ### Changed
-- Pass in initialAdminPassword to docker and update instances of admin:admin in READMEs. ([669](https://github.com/opensearch-project/opensearch-js/pull/669))
+- Pass in `OPENSEARCH_INITIAL_ADMIN_PASSWORD` to docker and update instances of admin:admin in READMEs. ([669](https://github.com/opensearch-project/opensearch-js/pull/669))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `@aws-sdk/types` from 3.451.0 to 3.468.0
 - Bumps `prettier` from 3.1.0 to 3.1.1
 ### Changed
+- Pass in initialAdminPassword to docker and update instances of admin:admin in READMEs. ([669](https://github.com/opensearch-project/opensearch-js/pull/669))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -26,7 +26,7 @@
 var host = 'localhost';
 var protocol = 'https';
 var port = 9200;
-var auth = `admin:${initialAdminPassword}`; // For testing only. Don't store credentials in code.
+var auth = `admin:<admin password>`; // For testing only. Don't store credentials in code.
 var ca_certs_path = '/full/path/to/root-ca.pem';
 
 // Optional client certificates if you don't want to use HTTP basic authentication.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -26,7 +26,7 @@
 var host = 'localhost';
 var protocol = 'https';
 var port = 9200;
-var auth = `admin:<admin password>`; // For testing only. Don't store credentials in code.
+var auth = `admin:myStrongPassword123!`; // For testing only. Don't store credentials in code.
 var ca_certs_path = '/full/path/to/root-ca.pem';
 
 // Optional client certificates if you don't want to use HTTP basic authentication.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -26,7 +26,7 @@
 var host = 'localhost';
 var protocol = 'https';
 var port = 9200;
-var auth = 'admin:${initialAdminPassword}'; // For testing only. Don't store credentials in code.
+var auth = `admin:${initialAdminPassword}`; // For testing only. Don't store credentials in code.
 var ca_certs_path = '/full/path/to/root-ca.pem';
 
 // Optional client certificates if you don't want to use HTTP basic authentication.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -26,7 +26,7 @@
 var host = 'localhost';
 var protocol = 'https';
 var port = 9200;
-var auth = 'admin:admin'; // For testing only. Don't store credentials in code.
+var auth = 'admin:${initialAdminPassword}'; // For testing only. Don't store credentials in code.
 var ca_certs_path = '/full/path/to/root-ca.pem';
 
 // Optional client certificates if you don't want to use HTTP basic authentication.

--- a/guides/advanced_index_actions.md
+++ b/guides/advanced_index_actions.md
@@ -7,7 +7,7 @@ Let's create a client instance, and an index named `movies`:
 ```javascript
 const { Client } = require('@opensearch-project/opensearch');
 const client = new Client({
-  node: 'https://admin:admin@localhost:9200',
+  node: `https://admin:${initialAdminPassword}@localhost:9200`,
   ssl: { rejectUnauthorized: false }
 });
 client.indices.create({index: 'movies'})

--- a/guides/advanced_index_actions.md
+++ b/guides/advanced_index_actions.md
@@ -7,7 +7,7 @@ Let's create a client instance, and an index named `movies`:
 ```javascript
 const { Client } = require('@opensearch-project/opensearch');
 const client = new Client({
-  node: `https://admin:<admin password>@localhost:9200`,
+  node: `https://admin:myStrongPassword123!@localhost:9200`,
   ssl: { rejectUnauthorized: false }
 });
 client.indices.create({index: 'movies'})

--- a/guides/advanced_index_actions.md
+++ b/guides/advanced_index_actions.md
@@ -7,7 +7,7 @@ Let's create a client instance, and an index named `movies`:
 ```javascript
 const { Client } = require('@opensearch-project/opensearch');
 const client = new Client({
-  node: `https://admin:${initialAdminPassword}@localhost:9200`,
+  node: `https://admin:<admin password>@localhost:9200`,
   ssl: { rejectUnauthorized: false }
 });
 client.indices.create({index: 'movies'})

--- a/guides/index_lifecycle.md
+++ b/guides/index_lifecycle.md
@@ -3,7 +3,7 @@ This guide covers OpenSearch JavaScript Client API actions for Index Lifecycle. 
 
 ## Setup
 
-In this guide, we will need an OpenSearch cluster with more than one node. Let's use the sample [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) to start a cluster with two nodes. The cluster's API will be available at `localhost:9200` with basic authentication enabled with default username and password of `admin:${initialAdminPassword}`.
+In this guide, we will need an OpenSearch cluster with more than one node. Let's use the sample [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) to start a cluster with two nodes. The cluster's API will be available at `localhost:9200` with basic authentication enabled with default username and password of `admin:<admin password>`.
 
 To start the cluster, run the following command:
 
@@ -18,7 +18,7 @@ Let's create a client instance to access this cluster:
 const { Client } = require('@opensearch-project/opensearch');
 
 const client = new Client({
-  node: `https://admin:${initialAdminPassword}@localhost:9200`,
+  node: `https://admin:<admin password>@localhost:9200`,
   ssl: { rejectUnauthorized: false }
 });
 

--- a/guides/index_lifecycle.md
+++ b/guides/index_lifecycle.md
@@ -18,7 +18,7 @@ Let's create a client instance to access this cluster:
 const { Client } = require('@opensearch-project/opensearch');
 
 const client = new Client({
-  node: `https://admin:<admin password>@localhost:9200`,
+  node: `https://admin:myStrongPassword123!@localhost:9200`,
   ssl: { rejectUnauthorized: false }
 });
 

--- a/guides/index_lifecycle.md
+++ b/guides/index_lifecycle.md
@@ -3,7 +3,7 @@ This guide covers OpenSearch JavaScript Client API actions for Index Lifecycle. 
 
 ## Setup
 
-In this guide, we will need an OpenSearch cluster with more than one node. Let's use the sample [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) to start a cluster with two nodes. The cluster's API will be available at `localhost:9200` with basic authentication enabled with default username and password of `admin:admin`.
+In this guide, we will need an OpenSearch cluster with more than one node. Let's use the sample [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) to start a cluster with two nodes. The cluster's API will be available at `localhost:9200` with basic authentication enabled with default username and password of `admin:${initialAdminPassword}`.
 
 To start the cluster, run the following command:
 
@@ -18,7 +18,7 @@ Let's create a client instance to access this cluster:
 const { Client } = require('@opensearch-project/opensearch');
 
 const client = new Client({
-  node: 'https://admin:admin@localhost:9200',
+  node: `https://admin:${initialAdminPassword}@localhost:9200`,
   ssl: { rejectUnauthorized: false }
 });
 

--- a/guides/msearch.md
+++ b/guides/msearch.md
@@ -8,7 +8,7 @@ OpenSearch's Multi-Search (`msearch`) API allows you to execute multiple search 
 const host = "localhost";
 const protocol = "https";
 const port = 9200;
-const auth = "admin:admin";
+const auth = "admin:${initialAdminPassword}";
 const ca_certs_path = "/full/path/to/root-ca.pem";
 const { Client } = require("@opensearch-project/opensearch");
 const fs = require("fs");

--- a/guides/msearch.md
+++ b/guides/msearch.md
@@ -8,7 +8,7 @@ OpenSearch's Multi-Search (`msearch`) API allows you to execute multiple search 
 const host = "localhost";
 const protocol = "https";
 const port = 9200;
-const auth = `admin:${initialAdminPassword}`;
+const auth = `admin:<admin password>`;
 const ca_certs_path = "/full/path/to/root-ca.pem";
 const { Client } = require("@opensearch-project/opensearch");
 const fs = require("fs");

--- a/guides/msearch.md
+++ b/guides/msearch.md
@@ -8,7 +8,7 @@ OpenSearch's Multi-Search (`msearch`) API allows you to execute multiple search 
 const host = "localhost";
 const protocol = "https";
 const port = 9200;
-const auth = `admin:<admin password>`;
+const auth = `admin:myStrongPassword123!`;
 const ca_certs_path = "/full/path/to/root-ca.pem";
 const { Client } = require("@opensearch-project/opensearch");
 const fs = require("fs");

--- a/guides/msearch.md
+++ b/guides/msearch.md
@@ -8,7 +8,7 @@ OpenSearch's Multi-Search (`msearch`) API allows you to execute multiple search 
 const host = "localhost";
 const protocol = "https";
 const port = 9200;
-const auth = "admin:${initialAdminPassword}";
+const auth = `admin:${initialAdminPassword}`;
 const ca_certs_path = "/full/path/to/root-ca.pem";
 const { Client } = require("@opensearch-project/opensearch");
 const fs = require("fs");

--- a/guides/search.md
+++ b/guides/search.md
@@ -6,7 +6,7 @@ Let's start by creating an index and adding some documents to it:
 var host = "localhost";
 var protocol = "https";
 var port = 9200;
-var auth = "admin:${initialAdminPassword}"; // For testing only. Don't store credentials in code.
+var auth = `admin:${initialAdminPassword}`; // For testing only. Don't store credentials in code.
 var ca_certs_path = "/full/path/to/root-ca.pem";
 
 // Optional client certificates if you don't want to use HTTP basic authentication.

--- a/guides/search.md
+++ b/guides/search.md
@@ -6,7 +6,7 @@ Let's start by creating an index and adding some documents to it:
 var host = "localhost";
 var protocol = "https";
 var port = 9200;
-var auth = `admin:${initialAdminPassword}`; // For testing only. Don't store credentials in code.
+var auth = `admin:<admin password>`; // For testing only. Don't store credentials in code.
 var ca_certs_path = "/full/path/to/root-ca.pem";
 
 // Optional client certificates if you don't want to use HTTP basic authentication.

--- a/guides/search.md
+++ b/guides/search.md
@@ -6,7 +6,7 @@ Let's start by creating an index and adding some documents to it:
 var host = "localhost";
 var protocol = "https";
 var port = 9200;
-var auth = "admin:admin"; // For testing only. Don't store credentials in code.
+var auth = "admin:${initialAdminPassword}"; // For testing only. Don't store credentials in code.
 var ca_certs_path = "/full/path/to/root-ca.pem";
 
 // Optional client certificates if you don't want to use HTTP basic authentication.

--- a/guides/search.md
+++ b/guides/search.md
@@ -6,7 +6,7 @@ Let's start by creating an index and adding some documents to it:
 var host = "localhost";
 var protocol = "https";
 var port = 9200;
-var auth = `admin:<admin password>`; // For testing only. Don't store credentials in code.
+var auth = `admin:myStrongPassword123!`; // For testing only. Don't store credentials in code.
 var ca_certs_path = "/full/path/to/root-ca.pem";
 
 // Optional client certificates if you don't want to use HTTP basic authentication.


### PR DESCRIPTION
### Description

Due to recent changes in the security plugin, the install demo configuration script now requires an initial admin password to be set. This sets it to some random variable so that the CI continues to work.

### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
