### PR TITLE
Add new types to package exports definition for ESM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Add new types to `package.json` exports configuration for ESM support ([#674](https://github.com/opensearch-project/opensearch-js/pull/674))
 ### Security
 
 ## [2.5.0]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
       "types": "./index.d.ts",
       "import": "./index.mjs"
     },
+    "./api/new": {
+      "types": "./api/new.d.ts"
+    },
+    "./api/types": {
+      "types": "./api/types.d.ts"
+    },
     "./aws": "./lib/aws/index.js",
     "./*": "./*"
   },


### PR DESCRIPTION
### Description

As of today, it's not possible to resolve the new typings with a TS project using ESM. With these changes, you can import types in ESM project, e.g.:

```typescript
import type { SearchHit, SearchResponse } from '@opensearch-project/opensearch/api/types'
```

This is also backwards compatible with projects converting from TS + CommonJS to TS + ESM.

### Issues Resolved

Closes #204 

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
