### PR TITLE
Add expiration buffer to prevent credentials to expire earlier than request may finish.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Updated `guides/index_lifecycle.md` to provide example of `ignore_unavailable: true` while deleting indices. ([665](https://github.com/opensearch-project/opensearch-js/pull/665))
+- Add expiration buffer to prevent credentials to expire earlier than request may finish in case AWS SDK v3 is used. ([678](https://github.com/opensearch-project/opensearch-js/pull/678))
 ### Dependencies
 - Bumps `@types/node` from 20.9.0 to 20.10.5
 - Bumps `eslint` from 8.54.0 to 8.56.0

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -99,8 +99,8 @@ const client = new Client({
     // Must return a Promise that resolve to an AWS.Credentials object.
     // This function is used to acquire the credentials when the client start and
     // when the credentials are expired.
-    // The Client will refresh the Credentials only when they are expired.
-    // With AWS SDK V2, Credentials.refreshPromise is used when available to refresh the credentials.
+    // The Client will treat the Credentials as expired if within
+    // `requestTimeout` ms of expiration (default is 30000 ms).
 
     // Example with AWS SDK V3:
     getCredentials: () => {
@@ -109,6 +109,7 @@ const client = new Client({
       return credentialsProvider();
     },
   }),
+  requestTimeout: 60000, // Also used for refreshing credentials in advance
   node: 'https://search-xxx.region.es.amazonaws.com', // OpenSearch domain URL
   // node: "https://xxx.region.aoss.amazonaws.com" for OpenSearch Serverless
 });

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -729,4 +729,5 @@ module.exports.internals = {
   randomSelector,
   generateRequestId,
   lowerCaseHeaders,
+  toMs,
 };

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -14,6 +14,7 @@ const Transport = require('../Transport');
 const aws4 = require('aws4');
 const AwsSigv4SignerError = require('./errors');
 const crypto = require('crypto');
+const { toMs } = Transport.internals;
 
 const getAwsSDKCredentialsProvider = async () => {
   // First try V3
@@ -102,6 +103,9 @@ function AwsSigv4Signer(opts = {}) {
       }
 
       const currentCredentials = credentialsState.credentials;
+      // For AWS SDK V3 make sure token is valid at least until request has timed out.
+      const EXPIRATION_BUFFER_MS = toMs(options.requestTimeout || this.requestTimeout) * 2;
+
       let expired = false;
       if (!currentCredentials) {
         // Credentials haven't been acquired yet.
@@ -120,7 +124,10 @@ function AwsSigv4Signer(opts = {}) {
         expired = true;
       }
       // AWS SDK V3, Credentials.expiration is a Date object
-      else if (currentCredentials.expiration && currentCredentials.expiration < new Date()) {
+      else if (
+        currentCredentials.expiration &&
+        currentCredentials.expiration.getTime() - Date.now() < EXPIRATION_BUFFER_MS
+      ) {
         expired = true;
       }
 

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -103,8 +103,11 @@ function AwsSigv4Signer(opts = {}) {
       }
 
       const currentCredentials = credentialsState.credentials;
-      // For AWS SDK V3 make sure token is valid at least until request has timed out.
-      const EXPIRATION_BUFFER_MS = toMs(options.requestTimeout || this.requestTimeout) * 2;
+      /**
+       * For AWS SDK V3
+       * Make sure token will expire no earlier than `expiryBufferMs` milliseconds in the future.
+       */
+      const expiryBufferMs = toMs(options.requestTimeout || this.requestTimeout);
 
       let expired = false;
       if (!currentCredentials) {
@@ -126,7 +129,7 @@ function AwsSigv4Signer(opts = {}) {
       // AWS SDK V3, Credentials.expiration is a Date object
       else if (
         currentCredentials.expiration &&
-        currentCredentials.expiration.getTime() - Date.now() < EXPIRATION_BUFFER_MS
+        currentCredentials.expiration.getTime() - Date.now() < expiryBufferMs
       ) {
         expired = true;
       }

--- a/test/unit/lib/aws/awssigv4signer.test.js
+++ b/test/unit/lib/aws/awssigv4signer.test.js
@@ -473,7 +473,7 @@ test('Basic aws failure to refresh credentials', (t) => {
   });
 });
 
-test('Basic aws sdk v3 when token TTL value is smaller than 2*requestTimeout', (t) => {
+test('Basic aws sdk v3 when token expires earlier than `requestTimeout` ms in the future.', (t) => {
   t.plan(4);
 
   function handler(req, res) {
@@ -494,7 +494,7 @@ test('Basic aws sdk v3 when token TTL value is smaller than 2*requestTimeout', (
             resolve({
               accessKeyId: uuidv4(),
               secretAccessKey: uuidv4(),
-              expiration: new Date(Date.now() + 1000 * 55),
+              expiration: new Date(Date.now() + 1000 * 25),
             });
           }, 100);
         }),
@@ -534,7 +534,7 @@ test('Basic aws sdk v3 when token TTL value is smaller than 2*requestTimeout', (
   });
 });
 
-test('Basic aws sdk v3 when token TTL value is slightly bigger than 2*requestTimeout', (t) => {
+test('Basic aws sdk v3 when token expires later than `requestTimeout` ms in the future.', (t) => {
   t.plan(4);
 
   function handler(req, res) {
@@ -555,7 +555,7 @@ test('Basic aws sdk v3 when token TTL value is slightly bigger than 2*requestTim
             resolve({
               accessKeyId: uuidv4(),
               secretAccessKey: uuidv4(),
-              expiration: new Date(Date.now() + 1000 * 65),
+              expiration: new Date(Date.now() + 1000 * 45),
             });
           }, 100);
         }),


### PR DESCRIPTION
### Description

Use 2x `requestTimeout` value as `expiration_buffer_ms` to make sure that whenever we make request credentials are valid for longer than request may be active and not time out (with added safety by using 2x value). 

### Issues Resolved

Fixes this: 
https://github.com/opensearch-project/opensearch-js/issues/677
### Check List

- [x ] New functionality includes testing.
  - [x ] All tests pass
- [ x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ x] Commits are signed per the DCO using --signoff
- [x ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
