### PR TITLE
Moved Sean Neumann to Emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ananzh @kavilla @seanneumann @dblock @VachaShah @nhtruong @harshavamsi @timursaurus
+* @ananzh @kavilla @dblock @VachaShah @nhtruong @harshavamsi @timursaurus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 |-----------------------|-----------------------------------------------|-------------|
 | Anan Zhuang           | [ananzh](https://github.com/ananzh)           | Amazon      |
 | Kawika (Rocky) Avilla | [kavilla](https://github.com/kavilla)         | Amazon      |
-| Sean Neumann          | [seanneumann](https://github.com/seanneumann) | Amazon      |
 | Daniel Doubrovkine    | [dblock](https://github.com/dblock)           | Amazon      |
 | Vacha Shah            | [VachaShah](https://github.com/VachaShah)     | Amazon      |
 | Theo Truong           | [nhtruong](https://github.com/nhtruong)       | Amazon      |
@@ -17,7 +16,8 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Emeritus
 
-| Maintainer    | GitHub ID                                 | Affiliation |
-|---------------|-------------------------------------------|-------------|
-| Bishoy Boktor | [boktorbb](https://github.com/boktorbb)   | Amazon      |
-| Mihir Soni    | [mihirsoni](https://github.com/mihirsoni) | Amazon      |
+| Maintainer    | GitHub ID                                     | Affiliation |
+|---------------|-----------------------------------------------|-------------|
+| Bishoy Boktor | [boktorbb](https://github.com/boktorbb)       | Amazon      |
+| Mihir Soni    | [mihirsoni](https://github.com/mihirsoni)     | Amazon      |
+| Sean Neumann  | [seanneumann](https://github.com/seanneumann) | Amazon      |


### PR DESCRIPTION
### Description
Moving Sean Neumann to Emritus to unblock the release workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
