### PR TITLE
check that node.roles is defined

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -676,6 +676,7 @@ function defaultNodeFilter(node) {
   // avoid cluster_manager or master only nodes
   // TODO: remove role check on master when master is not supported
   if (
+    node.roles &&
     (node.roles.cluster_manager === true || node.roles.master === true) &&
     node.roles.data === false &&
     node.roles.ingest === false


### PR DESCRIPTION
### Description

When using the Mock from "@elastic/elasticsearch-mock" the roles on the node are not defined, this pr checks that roles are defined before checking if the node is a cluster_manager or master only node.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-js/issues/640

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
