### PR TITLE
Make optional fields optional in `MappingGenericProperty` (#703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Make optional fields optional in `MappingGenericProperty` ([708](https://github.com/opensearch-project/opensearch-js/pull/708))
 ### Security
 
 ## [2.5.0]

--- a/api/types.d.ts
+++ b/api/types.d.ts
@@ -3907,17 +3907,17 @@ export interface MappingFloatRangeProperty extends MappingRangePropertyBase {
 }
 
 export interface MappingGenericProperty extends MappingDocValuesPropertyBase {
-  analyzer: string;
-  boost: double;
-  fielddata: IndicesStringFielddata;
-  ignore_malformed: boolean;
-  index: boolean;
-  index_options: MappingIndexOptions;
-  norms: boolean;
-  null_value: string;
-  position_increment_gap: integer;
-  search_analyzer: string;
-  term_vector: MappingTermVectorOption;
+  analyzer?: string;
+  boost?: double;
+  fielddata?: IndicesStringFielddata;
+  ignore_malformed?: boolean;
+  index?: boolean;
+  index_options?: MappingIndexOptions;
+  norms?: boolean;
+  null_value?: string;
+  position_increment_gap?: integer;
+  search_analyzer?: string;
+  term_vector?: MappingTermVectorOption;
   type: string;
 }
 

--- a/test/types/types.test-d.ts
+++ b/test/types/types.test-d.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+import { expectAssignable } from 'tsd';
+import { MappingProperty } from '../../api/types';
+
+// https://github.com/opensearch-project/opensearch-js/issues/703
+// only manifested when value is in a variable, so the following would *not* catch it:
+//
+// expectAssignable<MappingProperty>({ type: 'date' });
+
+const x = { type: 'date' };
+expectAssignable<MappingProperty>(x);


### PR DESCRIPTION
### Description

Make optional fields optional in `MappingGenericProperty`

### Issues Resolved

https://github.com/opensearch-project/opensearch-js/issues/703

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
