### PR TITLE
Inherit AwsSigV4 in .child 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Add child client support for AwsSigV4 ([#725](https://github.com/opensearch-project/opensearch-js/pull/725))
+- Inherit AwsSigV4 in .child ([#725](https://github.com/opensearch-project/opensearch-js/pull/725))
 ### Dependencies
 - Bumps `prettier` from 3.1.1 to 3.2.5
 - Bumps `@aws-sdk/types` from 3.485.0 to 3.523.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Add child client support for AwsSigV4 ([#725](https://github.com/opensearch-project/opensearch-js/pull/725))
 ### Dependencies
 - Bumps `prettier` from 3.1.1 to 3.2.5
 - Bumps `@aws-sdk/types` from 3.485.0 to 3.523.0

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,7 @@ import {
   CloudConnectionPool,
   ResurrectEvent,
   BasicAuth,
+  AwsSigv4Auth,
 } from './lib/pool';
 import Serializer from './lib/Serializer';
 import Helpers from './lib/Helpers';
@@ -126,7 +127,7 @@ interface ClientOptions {
   opaqueIdPrefix?: string;
   generateRequestId?: generateRequestIdFn;
   name?: string | symbol;
-  auth?: BasicAuth;
+  auth?: BasicAuth | AwsSigv4Auth;
   context?: Context;
   proxy?: string | URL;
   enableMetaHeader?: boolean;

--- a/index.js
+++ b/index.js
@@ -192,6 +192,7 @@ class Client extends OpenSearchAPI {
       opaqueIdPrefix: options.opaqueIdPrefix,
       context: options.context,
       memoryCircuitBreaker: options.memoryCircuitBreaker,
+      auth: options.auth,
     });
 
     this.helpers = new Helpers({

--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -32,7 +32,7 @@
 import { URL } from 'url';
 import { inspect, InspectOptions } from 'util';
 import { Readable as ReadableStream } from 'stream';
-import { BasicAuth } from './pool';
+import { BasicAuth, AwsSigv4Auth } from './pool';
 import * as http from 'http';
 import * as https from 'https';
 import * as hpagent from 'hpagent';
@@ -48,7 +48,7 @@ export interface ConnectionOptions {
   agent?: AgentOptions | agentFn;
   status?: string;
   roles?: ConnectionRoles;
-  auth?: BasicAuth;
+  auth?: BasicAuth | AwsSigv4Auth;
   proxy?: string | URL;
 }
 

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -333,6 +333,10 @@ function prepareHeaders(headers = {}, auth) {
       headers.authorization =
         'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
     }
+    if (auth.credentials && auth.region && auth.service) {
+      const originalString = `${auth.credentials.accessKeyId}:${auth.credentials.secretAccessKey}:${auth.credentials.sessionToken}:${auth.region}:${auth.service}`;
+      headers.authorization = Buffer.from(originalString).toString('base64');
+    }
   }
   return headers;
 }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -333,10 +333,6 @@ function prepareHeaders(headers = {}, auth) {
       headers.authorization =
         'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
     }
-    if (auth.credentials && auth.region && auth.service) {
-      const originalString = `${auth.credentials.accessKeyId}:${auth.credentials.secretAccessKey}:${auth.credentials.sessionToken}:${auth.region}:${auth.service}`;
-      headers.authorization = Buffer.from(originalString).toString('base64');
-    }
   }
   return headers;
 }

--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -82,6 +82,7 @@ interface TransportOptions {
   name?: string;
   opaqueIdPrefix?: string;
   memoryCircuitBreaker?: MemoryCircuitBreakerOptions;
+  auth?: BasicAuth | AwsSigv4Auth;
 }
 
 export interface RequestEvent<TResponse = Record<string, any>, TContext = Context> {

--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -30,7 +30,7 @@
 import { Readable as ReadableStream } from 'stream';
 import Connection from './Connection';
 import * as errors from './errors';
-import { CloudConnectionPool, ConnectionPool } from './pool';
+import { CloudConnectionPool, ConnectionPool, BasicAuth, AwsSigv4Auth } from './pool';
 import Serializer from './Serializer';
 
 export type ApiError =

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -198,8 +198,8 @@ class Transport {
       isStream(params.body) || isStream(params.bulkBody)
         ? 0
         : typeof options.maxRetries === 'number'
-        ? options.maxRetries
-        : this.maxRetries;
+          ? options.maxRetries
+          : this.maxRetries;
     const compression = options.compression !== undefined ? options.compression : this.compression;
     let request = { abort: noop };
     const transportReturn = {

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -496,7 +496,7 @@ class Transport {
           Object.assign({}, params.querystring, options.querystring)
         );
       }
-      if (this._auth !== undefined) {
+      if (this._auth !== null && typeof this._auth === 'object' && 'credentials' in this._auth) {
         params.auth = this._auth;
       }
 

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -197,8 +197,8 @@ class Transport {
       isStream(params.body) || isStream(params.bulkBody)
         ? 0
         : typeof options.maxRetries === 'number'
-          ? options.maxRetries
-          : this.maxRetries;
+        ? options.maxRetries
+        : this.maxRetries;
     const compression = options.compression !== undefined ? options.compression : this.compression;
     let request = { abort: noop };
     const transportReturn = {

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -101,6 +101,7 @@ class Transport {
     this._sniffEnabled = typeof this.sniffInterval === 'number';
     this._nextSniff = this._sniffEnabled ? Date.now() + this.sniffInterval : 0;
     this._isSniffing = false;
+    this._auth = opts.auth;
 
     if (opts.sniffOnStart === true) {
       // timer needed otherwise it will clash
@@ -494,6 +495,9 @@ class Transport {
         params.querystring = this.serializer.qserialize(
           Object.assign({}, params.querystring, options.querystring)
         );
+      }
+      if (this._auth !== undefined) {
+        params.auth = this._auth;
       }
 
       // handles request timeout

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -79,6 +79,22 @@ function AwsSigv4Signer(opts = {}) {
     request.region = opts.region;
     request.headers = request.headers || {};
     request.headers['host'] = request.hostname;
+
+    if (request.headers.authorization) {
+      const encodedString = request.headers.authorization;
+      const awsAuthorizationHeader = Buffer.from(encodedString, 'base64').toString('utf-8');
+      const awsSigV4AuthOptions = awsAuthorizationHeader.split(':');
+      credentialsState.credentials = {
+        accessKeyId: awsSigV4AuthOptions[0],
+        secretAccessKey: awsSigV4AuthOptions[1],
+        sessionToken: awsSigV4AuthOptions[2],
+      };
+      console.log(`credentialsState.credentials = ${JSON.stringify(credentialsState.credentials)}`);
+      request.region = awsSigV4AuthOptions[3];
+      request.service = awsSigV4AuthOptions[4];
+
+      delete request.headers.authorization;
+    }
     const signed = aws4.sign(request, credentialsState.credentials);
     signed.headers['x-amz-content-sha256'] = crypto
       .createHash('sha256')

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -80,20 +80,26 @@ function AwsSigv4Signer(opts = {}) {
     request.headers = request.headers || {};
     request.headers['host'] = request.hostname;
 
-    if (request.headers.authorization) {
-      const encodedString = request.headers.authorization;
-      const awsAuthorizationHeader = Buffer.from(encodedString, 'base64').toString('utf-8');
-      const awsSigV4AuthOptions = awsAuthorizationHeader.split(':');
+    if (request['auth']) {
+      const awssigv4Cred = request['auth'];
       credentialsState.credentials = {
-        accessKeyId: awsSigV4AuthOptions[0],
-        secretAccessKey: awsSigV4AuthOptions[1],
-        sessionToken: awsSigV4AuthOptions[2],
+        accessKeyId: awssigv4Cred.credentials.accessKeyId,
+        secretAccessKey: awssigv4Cred.credentials.secretAccessKey,
+        sessionToken: awssigv4Cred.credentials.sessionToken,
       };
       console.log(`credentialsState.credentials = ${JSON.stringify(credentialsState.credentials)}`);
-      request.region = awsSigV4AuthOptions[3];
-      request.service = awsSigV4AuthOptions[4];
+      request.region = awssigv4Cred.region;
+      request.service = awssigv4Cred.service;
 
-      delete request.headers.authorization;
+      console.log(
+        `Does auth present in request? ===> ${
+          request['auth'] ? 'YES. Please delete once job is done' : 'NO'
+        }`
+      );
+      delete request['auth'];
+      console.log(
+        `Have auth deleted from request successfully? ===> ${request['auth'] ? 'NO' : 'YES'}`
+      );
     }
     const signed = aws4.sign(request, credentialsState.credentials);
     signed.headers['x-amz-content-sha256'] = crypto

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -87,7 +87,6 @@ function AwsSigv4Signer(opts = {}) {
         secretAccessKey: awssigv4Cred.credentials.secretAccessKey,
         sessionToken: awssigv4Cred.credentials.sessionToken,
       };
-      console.log(`credentialsState.credentials = ${JSON.stringify(credentialsState.credentials)}`);
       request.region = awssigv4Cred.region;
       request.service = awssigv4Cred.service;
       delete request['auth'];

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -90,16 +90,7 @@ function AwsSigv4Signer(opts = {}) {
       console.log(`credentialsState.credentials = ${JSON.stringify(credentialsState.credentials)}`);
       request.region = awssigv4Cred.region;
       request.service = awssigv4Cred.service;
-
-      console.log(
-        `Does auth present in request? ===> ${
-          request['auth'] ? 'YES. Please delete once job is done' : 'NO'
-        }`
-      );
       delete request['auth'];
-      console.log(
-        `Have auth deleted from request successfully? ===> ${request['auth'] ? 'NO' : 'YES'}`
-      );
     }
     const signed = aws4.sign(request, credentialsState.credentials);
     signed.headers['x-amz-content-sha256'] = crypto

--- a/lib/pool/index.d.ts
+++ b/lib/pool/index.d.ts
@@ -38,7 +38,7 @@ interface BaseConnectionPoolOptions {
   ssl?: SecureContextOptions;
   agent?: AgentOptions;
   proxy?: string | URL;
-  auth?: BasicAuth;
+  auth?: BasicAuth | AwsSigv4Auth;
   emit: (event: string | symbol, ...args: any[]) => boolean;
   Connection: typeof Connection;
 }
@@ -60,6 +60,16 @@ interface getConnectionOptions {
 interface BasicAuth {
   username: string;
   password: string;
+}
+
+interface AwsSigv4Auth {
+  credentials : {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken: string;
+  }
+  region: string;
+  service: string;
 }
 
 interface resurrectOptions {
@@ -85,7 +95,7 @@ declare class BaseConnectionPool {
   _ssl: SecureContextOptions | null;
   _agent: AgentOptions | null;
   _proxy: string | URL;
-  auth: BasicAuth;
+  auth: BasicAuth | AwsSigv4Auth;
   Connection: typeof Connection;
   constructor(opts?: BaseConnectionPoolOptions);
   /**
@@ -235,6 +245,7 @@ export {
   ConnectionPoolOptions,
   getConnectionOptions,
   BasicAuth,
+  AwsSigv4Auth,
   internals,
   resurrectOptions,
   ResurrectEvent,

--- a/test/unit/lib/aws/awssigv4signer.test.js
+++ b/test/unit/lib/aws/awssigv4signer.test.js
@@ -596,7 +596,7 @@ test('Basic aws sdk v3 when token expires later than `requestTimeout` ms in the 
   });
 });
 
-test('Should create child client (auth check)', (t) => {
+test('Should create child client', (t) => {
   t.plan(8);
   const childClientCred = {
     auth: {
@@ -689,7 +689,7 @@ test('Should create child client (auth check)', (t) => {
     child.on('request', (err, { meta }) => {
       debug('Count', count);
       if (count === 0) {
-        t.equal(JSON.stringify(meta.request.params.auth), 'null');
+        t.equal(JSON.stringify(meta.request.params.auth), undefined);
       } else if (count === 1) {
         t.equal(JSON.stringify(meta.request.params.auth), JSON.stringify(childClientCred.auth));
       } else if (count === 2) {


### PR DESCRIPTION
### Description

There are some use cases where you may need multiple instances of the client. You can easily do that by calling new `Client()` as many times as you need, but you will lose all the benefits of using one single client, such as the long living connections and the connection pool handling.

As of today, we have `client.child` API, which returns a new client instance that shares the connection pool with the parent client. But this only supported for Basic Authentication type (with username and password). This PR adds the child client support for AWSSigv4. 

Example:
```
const client = new Client({
  ...AwsSigv4Signer({
    region: 'us-west-2',
    service: 'es',
    getCredentials: () =>
      new Promise((resolve, reject) => {
        AWS.config.getCredentials((err, credentials) => {
          if (err) {
            reject(err);
          } else {
            resolve(credentials);
          }
        });
      }),
  }),
  node: 'https://search-xxx.region.es.amazonaws.com', // OpenSearch domain URL
});

const child = client.child({
  auth: {
        credentials: {
          accessKeyId: 'foo',
          secretAccessKey: 'bar',
          sessionToken: 'foobar',
        },
        region: 'eu-west-1',
        service: 'es',
      }
});
```

### Issues Resolved

#696

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Linter check was successfull - `yarn run lint` doesn't show any errors
- [X] Commits are signed per the DCO using --signoff
- [X] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
