### PR TITLE
fix typo in msearch guide (index -> indices)

### DIFF
--- a/guides/msearch.md
+++ b/guides/msearch.md
@@ -18,7 +18,7 @@ await client.bulk({
   ],
 });
 
-await client.index.refresh({ index: 'movies' });
+await client.indices.refresh({ index: 'movies' });
 ```
 
 # Multi Search API


### PR DESCRIPTION
It causes "TypeError: **client.index.refresh** is not a function" when trying to run the sample codes in **msearch.md**.

### Description

There is a typo in msearch.md. 
The "client.**index**.refresh" in "await client.index.refresh({ index: 'movies' });" should be "client.**indices**.refresh" instead.

### Issues Resolved

Fix a typo in msearch.md.

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
