### PR TITLE
fix: missing type definitions for aws-v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Missing type definitions for `@opensearch-project/opensearch/aws-v3` ([776](https://github.com/opensearch-project/opensearch-js/pull/776)).
 ### Security
 
 ## [2.8.0]

--- a/lib/aws/index-v3.d.ts
+++ b/lib/aws/index-v3.d.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+/// <reference types="node" />
+
+import {
+  AwsSigv4Signer,
+  AwsSigv4SignerError,
+  AwsSigv4SignerOptions,
+  AwsSigv4SignerResponse,
+} from './index';
+
+export { AwsSigv4Signer, AwsSigv4SignerOptions, AwsSigv4SignerResponse, AwsSigv4SignerError };

--- a/test/types/awssigv4signer-v3.test-d.ts
+++ b/test/types/awssigv4signer-v3.test-d.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+import { expectType } from 'tsd';
+const { v4: uuidv4 } = require('uuid');
+import {
+  AwsSigv4SignerResponse as AwsSigv4SignerResponseV3,
+  AwsSigv4Signer as AwsSigv4SignerV3,
+} from '../../lib/aws/index-v3';
+
+const mockCreds = {
+  accessKeyId: uuidv4(),
+  secretAccessKey: uuidv4(),
+  expired: false,
+  expireTime: new Date(),
+  sessionToken: uuidv4(),
+};
+
+const mockRegion = 'us-east-1';
+
+{
+  const AwsSigv4SignerOptions = {
+    getCredentials: () => Promise.resolve(mockCreds),
+    region: mockRegion,
+  };
+
+  const auth = AwsSigv4SignerV3(AwsSigv4SignerOptions);
+
+  expectType<AwsSigv4SignerResponseV3>(auth);
+}


### PR DESCRIPTION
### Description

Add type definitions for aws-v3.

### Issues Resolved

https://github.com/opensearch-project/opensearch-js/issues/771

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Linter check was successfull - `yarn run lint` doesn't show any errors
- [X] Commits are signed per the DCO using --signoff
- [X] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
