### PR TITLE
Add missing types in package.json for aws-v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Add missing types in `package.json` for `aws-v3` ([810](https://github.com/opensearch-project/opensearch-js/pull/810))
 ### Security
 
 ## [2.10.0]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
       ],
       "aws": [
         "./lib/aws/index.d.ts"
+      ],
+      "aws-v3": [
+        "./lib/aws/index-v3.d.ts"
       ]
     }
   },


### PR DESCRIPTION
### Description

Adds a reference in package.json for the aws-v3 types

### Issues Resolved

Closes #771 

### Check List

- [x] New functionality includes testing.
- [x] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
