### PR TITLE
Implement TransportRequestPromise, TransportRequestCallback in AWS Signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `@types/node` from 20.14.10 to 20.14.11
 - Bumps `eslint-plugin-prettier` from 5.1.3 to 5.2.1
 ### Changed
+- Return a transport object from `AwsSigv4SignerTransport.request` that has an `.abort()` method that allows in-flight requests to be canceled
 ### Deprecated
 ### Removed
 ### Fixed

--- a/lib/aws/shared.js
+++ b/lib/aws/shared.js
@@ -13,8 +13,11 @@ const Connection = require('../Connection');
 const Transport = require('../Transport');
 const aws4 = require('aws4');
 const AwsSigv4SignerError = require('./errors');
+const { RequestAbortedError } = require('../errors');
 const crypto = require('crypto');
 const { toMs } = Transport.internals;
+
+const noop = () => {};
 
 function giveAwsCredentialProviderLoader(getAwsSDKCredentialsProvider) {
   return function loadAwsCredentialProvider() {
@@ -118,45 +121,88 @@ function giveAwsV4Signer(awsDefaultCredentialsProvider) {
         }
 
         if (!expired) {
-          if (typeof callback === 'undefined') {
+          if (callback === undefined) {
             return super.request(params, options);
+          } else {
+            return super.request(params, options, callback);
           }
-          super.request(params, options, callback);
-          return;
         }
 
-        // In AWS SDK V2 Credentials.refreshPromise should be available.
-        if (currentCredentials && typeof currentCredentials.refreshPromise === 'function') {
-          if (typeof callback === 'undefined') {
-            return currentCredentials.refreshPromise().then(() => {
-              return super.request(params, options);
-            });
-          } else {
+        let p = null;
+
+        // promises support
+        if (callback === undefined) {
+          let onFulfilled = null;
+          let onRejected = null;
+          p = new Promise((resolve, reject) => {
+            onFulfilled = resolve;
+            onRejected = reject;
+          });
+          callback = function callback(err, result) {
+            err ? onRejected(err) : onFulfilled(result);
+          };
+        }
+
+        const meta = {
+          aborted: false,
+        };
+
+        let request = { abort: noop };
+
+        const transportReturn = {
+          then(onFulfilled, onRejected) {
+            if (p != null) {
+              return p.then(onFulfilled, onRejected);
+            }
+          },
+          catch(onRejected) {
+            if (p != null) {
+              return p.catch(onRejected);
+            }
+          },
+          abort() {
+            meta.aborted = true;
+            request.abort();
+            return this;
+          },
+          finally(onFinally) {
+            if (p != null) {
+              return p.finally(onFinally);
+            }
+          },
+        };
+
+        const makeRequest = () => {
+          // In AWS SDK V2 Credentials.refreshPromise should be available.
+          if (currentCredentials && typeof currentCredentials.refreshPromise === 'function') {
             currentCredentials
               .refreshPromise()
               .then(() => {
-                super.request(params, options, callback);
+                if (meta.aborted) {
+                  return callback(new RequestAbortedError());
+                }
+                request = super.request(params, options, callback);
               })
               .catch(callback);
-            return;
           }
-        }
+          // For AWS SDK V3.
+          else {
+            opts
+              .getCredentials()
+              .then((credentials) => {
+                if (meta.aborted) {
+                  return callback(new RequestAbortedError());
+                }
+                credentialsState.credentials = credentials;
+                request = super.request(params, options, callback);
+              })
+              .catch(callback);
+          }
+        };
 
-        // For AWS SDK V3 or when the client has not acquired credentials yet.
-        if (typeof callback === 'undefined') {
-          return opts.getCredentials().then((credentials) => {
-            credentialsState.credentials = credentials;
-            return super.request(params, options);
-          });
-        } else {
-          opts
-            .getCredentials()
-            .then((credentials) => {
-              credentialsState.credentials = credentials;
-              super.request(params, options, callback);
-            })
-            .catch(callback);
-        }
+        makeRequest();
+
+        return transportReturn;
       }
     }
 


### PR DESCRIPTION
### Description

It was previously not possible to abort a request that used the AWS SigV4 signer transport.

### Issues Resolved

Fixes #819

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Linter check was successfull - `yarn run lint` doesn't show any errors
- [X] Commits are signed per the DCO using --signoff
- [X] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
