### PR TITLE
Upgrade build-lib version in release pipeline to accomodate new changes

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.1.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.9.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -7,5 +7,7 @@ standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-opensearch-js-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-js repository causing this workflow to run',
     publishRelease: true) {
-        publishToNpm(repository: 'https://github.com/opensearch-project/opensearch-js', tag: "$tag")
+        publishToNpm(
+            publicationType: 'github'
+            )
     }


### PR DESCRIPTION
### Description

The new changes include:
- Tagging the release as per the version suffix in the GitHub Tag.
- Add publication type argument.

This change uses the GitHub tag used to release an artifact to tag the release on npmjs.org as well. As of now everything is mark latest as default which is not right. beta should be tagged as beta and same goes for other tags such as rc, alpha, etc.
See https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/6.9.0

This version parses the github tag and accordingly uses it in while publishing to npmjs.org

### Issues Resolved

resolves #849 

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
