### PR TITLE
Replace JSON11-produced hex escape codes with unicode escape codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Replace JSON11-produced hex escape codes with unicode escape codes ([#879](https://github.com/opensearch-project/opensearch-js/pull/879))
 ### Security
 
 ## [3.0.0]

--- a/lib/Serializer.js
+++ b/lib/Serializer.js
@@ -37,6 +37,7 @@ const kJsonOptions = Symbol('secure json parse options');
 const JSON11 = require('json11');
 
 const isBigIntSupported = typeof BigInt !== 'undefined';
+const hexEscapeRegex = /\\x([0-9A-Fa-f]{2})/g;
 
 class Serializer {
   constructor(opts = {}) {
@@ -81,7 +82,7 @@ class Serializer {
             quote: '"',
             quoteNames: true,
           });
-          if (temp) json = temp;
+          if (temp) json = temp.replace(hexEscapeRegex, (_, c) => "\\u00".append(c));
         } catch (ex) {
           // Do nothing: JSON.stringify succeeded but JSON11.stringify failed; return the
           // JSON.stringify result.

--- a/test/unit/serializer.test.js
+++ b/test/unit/serializer.test.js
@@ -271,3 +271,10 @@ test('disable prototype poisoning protection only for constructor', (t) => {
     t.fail(err);
   }
 });
+
+test('Long numerals and ANSI escape sequences', (t) => {
+  t.plan(1);
+  const s = new Serializer({ enableLongNumeralSupport: true });
+  const obj = {message: "hello \u001b[38;7;2mworld\u001b[0m", value: BigInt(Number.MAX_SAFE_INTEGER) * 2n};
+  t.same(s.deserialize(s.serialize(obj)), obj);
+})


### PR DESCRIPTION
### Description

Since #784, `JSON11.stringify` produces JSON5 documents with hex escape codes (`\x1b`), which aren't standard JSON and cause `JSON.parse` to error. When using JSON11 code path, this PR applies a fix to replace all `\xXX` escape codes with the JSON-compatible equivalent Unicode escape codes (`\u00XX`).

This PR adds a unit test verifying the fix by ensuring a round-trip `s.deserialize(s.serialize(obj))` with an object containing long numerals and ANSI escape sequences completes successfully without error.

### Issues Resolved

Fixes opensearch-project/OpenSearch-Dashboards#7367.

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.