### PR TITLE
[Generator] Rendering string constants and anyOf with complex members

### DIFF
--- a/api_generator/src/renderers/templates/type.containers.mustache
+++ b/api_generator/src/renderers/templates/type.containers.mustache
@@ -9,6 +9,6 @@ import * as {{{name}}} from '{{{path}}}'
 {{/imports}}
 
 {{#types}}
-export {{{declarative}}} {{{definition}}}
+export type {{{name}}} = {{{definition}}}
 
 {{/types}}


### PR DESCRIPTION
This PR is to address the issues in #886.

---

### 1. Added ability to render string constants: 
To add more info for each member of the ExpandWildcard enum, we have [converted](https://github.com/opensearch-project/opensearch-api-specification/commit/4d74a4908c3cd4549cae820852c0c19cafaf6be2) its schema into an `oneOf` object where each member is a string constant. This changes causes the generator to create:
`type ExpandWildcard = 'string' | 'string' | 'string' | 'string' | 'string'`
instead of 
`type ExpandWildcard = 'all' | 'closed' | 'hidden' | 'none' | 'open'` 
we're adding another [guard](https://github.com/opensearch-project/opensearch-js/compare/main...nhtruong:api_gen/fix?expand=1#diff-372dafcf8e73848c89f2b2448e52a6fdfc35d985fd1467d2bf77846d3bbea87aR52) to handle `const` for the renderer.

---

### 2. Added ability to render `anyOf` objects where members can be anonymous objects:
The `InlineScript` is [now](https://github.com/opensearch-project/opensearch-api-specification/commit/6b637597197a46c2393d640cc8b8694989f842e7#diff-d0f830f71ab7d397979c992f08b0961c44d1fcc4242aaab103d6c98493327a1cR453-R471) an `anyOf` object where a member is a string, and another is a complex anonymous object, previously the generator will do:
```ts
export type InlineScript = string | extends ScriptBase {
  lang?: ScriptLanguage;
  options?: Record<string, string>;
  source: string;
})
```
which is not a valid type definition. The changes in [render_anyOf](https://github.com/opensearch-project/opensearch-js/compare/main...nhtruong:api_gen/fix?expand=1#diff-372dafcf8e73848c89f2b2448e52a6fdfc35d985fd1467d2bf77846d3bbea87aR65-R70) and [render_allOf](https://github.com/opensearch-project/opensearch-js/compare/main...nhtruong:api_gen/fix?expand=1#diff-372dafcf8e73848c89f2b2448e52a6fdfc35d985fd1467d2bf77846d3bbea87aR73-R92) functions will render
```ts
export type InlineScript = string | (ScriptBase & {
  lang?: ScriptLanguage;
  options?: Record<string, string>;
  source: string;
})
```

---

### 3. All type definitions are now `type` instead of a mix of `type` and `interface`
Previously the generator would generate `interface X` whenever possible and would generate `type X =` when not. The reason? Precedence. So we ended up with a mix of `type` and `interface` declarations. These changes [[1]](https://github.com/opensearch-project/opensearch-js/compare/main...nhtruong:api_gen/fix?expand=1#diff-372dafcf8e73848c89f2b2448e52a6fdfc35d985fd1467d2bf77846d3bbea87aL36-L40), [[2]](https://github.com/opensearch-project/opensearch-js/compare/main...nhtruong:api_gen/fix?expand=1#diff-372dafcf8e73848c89f2b2448e52a6fdfc35d985fd1467d2bf77846d3bbea87aL49-L56), [[3]](https://github.com/opensearch-project/opensearch-js/compare/main...nhtruong:api_gen/fix?expand=1#diff-b7b7405644df3c84577a68ef081beda16b48b819c1bd8ee268b47e412147dc3cL12),  simplifies the rendering logic to always render `type`, which is also a lot more flexible (which enables change No.2 above) and better mirror JSON Schema's `allOf`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
