### PR TITLE
Fix typo cause it will always trigger JSON11 parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data
+- Fixed typo cause JSON11 parse will always be execute when json string has number inside
 ### Security
 
 ## [3.0.0]

--- a/lib/Serializer.js
+++ b/lib/Serializer.js
@@ -101,7 +101,7 @@ class Serializer {
       if (
         numeralsAreNumbers &&
         typeof val === 'number' &&
-        (val < Number.MAX_SAFE_INTEGER || val > Number.MAX_SAFE_INTEGER)
+        (val < Number.MIN_SAFE_INTEGER || val > Number.MAX_SAFE_INTEGER)
       ) {
         numeralsAreNumbers = false;
       }


### PR DESCRIPTION
### Description

Fix typo cause it will always trigger JSON11 parse.

if the json string has number in it, `numeralsAreNumbers` will always be true. 

`(val < Number.MAX_SAFE_INTEGER || val > Number.MAX_SAFE_INTEGER) ` 

should changed to `(val < Number.MIN_SAFE_INTEGER || val > Number.MAX_SAFE_INTEGER) `

https://github.com/opensearch-project/opensearch-js/blob/92884503d80269ba08099040ce20c6aac9a2c4ab/lib/Serializer.js#L101-L107

then it will always trigger JSON11 parse

https://github.com/opensearch-project/opensearch-js/blob/92884503d80269ba08099040ce20c6aac9a2c4ab/lib/Serializer.js#L128-L137

### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
