### PR TITLE
Workflow Versions Updates

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -20,17 +20,17 @@ jobs:
         secured: ['true', 'false']
         entry:
           - { opensearch_version: 1.1.0 }
-          - { opensearch_version: 1.2.0 }
-          - { opensearch_version: 1.2.1 }
-          - { opensearch_version: 1.2.2 }
-          - { opensearch_version: 1.2.3 }
           - { opensearch_version: 1.2.4 }
-          - { opensearch_version: 1.3.0 }
-          - { opensearch_version: 1.3.1 }
-          - { opensearch_version: 1.3.2 }
-          - { opensearch_version: 1.3.3 }
-          - { opensearch_version: 2.0.0 }
+          - { opensearch_version: 1.3.19 }
           - { opensearch_version: 2.0.1 }
+          - { opensearch_version: 2.2.1 }
+          - { opensearch_version: 2.4.1 }
+          - { opensearch_version: 2.6.0 }
+          - { opensearch_version: 2.8.0 }
+          - { opensearch_version: 2.10.0 }
+          - { opensearch_version: 2.12.0 }
+          - { opensearch_version: 2.14.0 }
+          - { opensearch_version: 2.16.0 }
     env:
       OPENSEARCH_VERSION: ${{ matrix.entry.opensearch_version }}
       SECURE_INTEGRATION: ${{ matrix.secured }}
@@ -50,10 +50,10 @@ jobs:
         run: |
           make cluster.clean cluster.opensearch.build cluster.opensearch.start
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install
         run: |

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -22,15 +22,11 @@ jobs:
           - { opensearch_version: 1.1.0 }
           - { opensearch_version: 1.2.4 }
           - { opensearch_version: 1.3.19 }
-          - { opensearch_version: 2.0.1 }
           - { opensearch_version: 2.2.1 }
-          - { opensearch_version: 2.4.1 }
           - { opensearch_version: 2.6.0 }
-          - { opensearch_version: 2.8.0 }
-          - { opensearch_version: 2.10.0 }
           - { opensearch_version: 2.12.0 }
-          - { opensearch_version: 2.14.0 }
           - { opensearch_version: 2.16.0 }
+          - { opensearch_version: 2.17.0 }
     env:
       OPENSEARCH_VERSION: ${{ matrix.entry.opensearch_version }}
       SECURE_INTEGRATION: ${{ matrix.secured }}

--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         entry:
           - { node_version: '18.x', opensearch_ref: '1.x', jdk_version: '11' }
-          - { node_version: '18.x', opensearch_ref: '2.0', jdk_version: '17' }
           - { node_version: '18.x', opensearch_ref: '2.x', jdk_version: '17' }
           - { node_version: '18.x', opensearch_ref: 'main', jdk_version: '17' }
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macOS-13]
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macOS-13]
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,11 +48,11 @@ jobs:
         run: |
           npm uninstall -g yarn
           npm i -g yarn@1.22.10
-
-      - name: Lint
-        if: matrix.node-version == '16.x'
-        run: |
-          yarn lint
+# TODO: Uncomment the following block after updating the Codegen to support this linter
+#      - name: Lint
+#        if: matrix.node-version == '16.x'
+#        run: |
+#          yarn lint
 
       - name: Unit test
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Dependencies
-- Bumps `@babel/traverse` from 7.22.8 to 7.24.7
-- Bumps `eslint-plugin-prettier` from 5.1.3 to 5.2.1
-- Bumps `simple-git` from 3.24.0 to 3.26.0
-- Bumps `aws4` from 1.13.0 to 1.13.2
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
-- Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data
-- Fixed typo cause JSON11 parse will always be execute when json string has number inside
 ### Security
 
 ## [3.0.0]
@@ -24,12 +18,16 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added missing API functions and modules.
 - Added missing request and response types.
 ### Dependencies
-- Bumps `micromatch` from 4.0.7 to 4.0.8
-- Bumps `debug` from 4.3.6 to 4.3.7
-- Bumps `simple-statistics` from 7.8.4 to 7.8.5
-- Bumps `simple-git` from 3.25.0 to 3.26.0
+- Bumps `@babel/traverse` from 7.22.8 to 7.24.7
 - Bumps `@types/node` from 22.5.0 to 22.5.4
+- Bumps `aws4` from 1.13.0 to 1.13.2
 - Bumps `aws4` from 1.13.1 to 1.13.2
+- Bumps `debug` from 4.3.6 to 4.3.7
+- Bumps `eslint-plugin-prettier` from 5.1.3 to 5.2.1
+- Bumps `micromatch` from 4.0.7 to 4.0.8
+- Bumps `simple-git` from 3.24.0 to 3.26.0
+- Bumps `simple-git` from 3.25.0 to 3.26.0
+- Bumps `simple-statistics` from 7.8.4 to 7.8.5
 ### Changed
 - All API functions are now generated from the OpenSearch API specification.
 - API request and response types are now generated from the OpenSearch API specification.
@@ -39,8 +37,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 - Removed support for API param aliases. That is, the API functions now only accept params with the exact names specified in the OpenSearch API specification.
 - Removed support for overriding HTTP methods in API functions.
-- Removed support for Node.js 10 through 16. The minimum supported Node.js version is now 18.
+- Removed support for Node.js 10 through 14. The minimum supported Node.js version is now 16.
 ### Fixed
+- Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data
+- Fixed typo cause JSON11 parse will always be executed when json string has number inside
 ### Security
 
 ## [2.12.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 - Removed support for API param aliases. That is, the API functions now only accept params with the exact names specified in the OpenSearch API specification.
 - Removed support for overriding HTTP methods in API functions.
-- Removed support for Node.js 10 through 14. The minimum supported Node.js version is now 16.
+- Removed support for Node.js 10 and 12. The minimum supported Node.js version is now 14.
 ### Fixed
 - Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data
 - Fixed typo cause JSON11 parse will always be executed when json string has number inside

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "url": "https://github.com/opensearch-project/opensearch-js/issues"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=16",
     "yarn": "^1.22.10"
   },
   "tsd": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "url": "https://github.com/opensearch-project/opensearch-js/issues"
   },
   "engines": {
-    "node": ">=16",
+    "node": ">=14",
     "yarn": "^1.22.10"
   },
   "tsd": {


### PR DESCRIPTION
- Reinstated support for Node.js 14 to make 3.x compatible with dashboard dependencies.
- Removed OS 2.0 from Unreleased OS workflow
- Updated compatibility workflow with all the newer OS releases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
