### PR TITLE
Fixed flaky circuitBreaker unit test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data
 - Fixed typo cause JSON11 parse will always be executed when json string has number inside
-- Fixed flaky circuitBreaker unit test.
 ### Security
 
 ## [2.12.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data
 - Fixed typo cause JSON11 parse will always be executed when json string has number inside
+- Fixed flaky circuitBreaker unit test.
 ### Security
 
 ## [2.12.0]

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1037,7 +1037,7 @@ test('Content length too big (string)', (t) => {
 
 test('Content length exceeds max heap limit', (t) => {
   t.plan(4);
-  const percentage = 0.8;
+  const percentage = 0.01;
   const HEAP_SIZE_LIMIT = require('v8').getHeapStatistics().heap_size_limit;
   const contentLength = Math.round(HEAP_SIZE_LIMIT * percentage + 1);
   const memoryCircuitBreaker = {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1038,26 +1038,12 @@ test('Content length too big (string)', (t) => {
 test('Content length exceeds max heap limit', (t) => {
   t.plan(4);
   const percentage = 0.8;
-  const HEAP_SIZE_LIMIT_WITH_BUFFER = Number(
-    require('v8').getHeapStatistics().heap_size_limit * percentage
-  );
-  const contentLength = buffer.constants.MAX_STRING_LENGTH - 1;
+  const HEAP_SIZE_LIMIT = require('v8').getHeapStatistics().heap_size_limit;
+  const contentLength = Math.round(HEAP_SIZE_LIMIT * percentage + 1);
   const memoryCircuitBreaker = {
     enabled: true,
     maxPercentage: percentage,
   };
-  // Simulate allocation of bytes
-  const memoryAllocations = [];
-  while (process.memoryUsage().heapUsed + contentLength <= HEAP_SIZE_LIMIT_WITH_BUFFER) {
-    const allocation = 50 * 1024 * 1024; // 50MB
-    const numbers = allocation / 8;
-    const arr = [];
-    arr.length = numbers;
-    for (let i = 0; i < numbers; i++) {
-      arr[i] = i;
-    }
-    memoryAllocations.push(arr);
-  }
 
   class MockConnection extends Connection {
     request(params, callback) {


### PR DESCRIPTION
Here's the actual code in Transport.js:
```js
    const MAX_STRING_LENGTH = buffer.constants.MAX_STRING_LENGTH;
    const HEAP_SIZE_LIMIT = require('v8').getHeapStatistics().heap_size_limit;
    ...
    const shouldApplyCircuitBreaker = (contentLength) => {
      if (!this.memoryCircuitBreaker || !this.memoryCircuitBreaker.enabled) return false;
      const maxPercentage = validateMemoryPercentage(this.memoryCircuitBreaker.maxPercentage);
      const heapUsed = process.memoryUsage().heapUsed;
      return contentLength + heapUsed > HEAP_SIZE_LIMIT * maxPercentage;
    };
```
However the current unit test sets the contentLength off of `MAX_STRING_LENGTH` instead of `HEAP_SIZE_LIMIT`. This results in the test failing on [earlier versions](https://github.com/opensearch-project/opensearch-js/actions/runs/11600222332?pr=892) of node.js where `heapUsed` is smaller and doesn't cause `contentLength + heapUsed > HEAP_SIZE_LIMIT * maxPercentage` to return true.

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
