### PR TITLE
[api_generator] API path builder update

### DIFF
--- a/api_generator/src/renderers/render_code/FunctionFileRenderer.ts
+++ b/api_generator/src/renderers/render_code/FunctionFileRenderer.ts
@@ -92,7 +92,7 @@ export default class FunctionFileRenderer extends BaseRenderer {
         path: path.build(true)
       }
     })
-    diverged_paths[0].guard = 'if'
+    diverged_paths[0].guard = ' if'
     diverged_paths[diverged_paths.length - 1].guard = 'else'
     diverged_paths[diverged_paths.length - 1].condition = ''
     return diverged_paths

--- a/api_generator/src/renderers/templates/function.mustache
+++ b/api_generator/src/renderers/templates/function.mustache
@@ -40,7 +40,7 @@ function {{{function_name}}}(params, options, callback) {
   {{^paths_are_uniform}}
   let path;
   {{#diverged_paths}}
-  {{{guard}}}{{{condition}}} {
+ {{{guard}}}{{{condition}}} {
     path = {{{path}}};
   }{{/diverged_paths}}
   {{/paths_are_uniform}}

--- a/api_generator/src/renderers/templates/function.mustache
+++ b/api_generator/src/renderers/templates/function.mustache
@@ -34,7 +34,16 @@ function {{{function_name}}}(params, options, callback) {
   {{{.}}} = parsePathParam({{{.}}});
   {{/path_params}}
 
-  const path = {{{path}}};
+  {{#paths_are_uniform}}
+  const path = {{{uniform_path}}};
+  {{/paths_are_uniform}}
+  {{^paths_are_uniform}}
+  let path;
+  {{#diverged_paths}}
+  {{{guard}}}{{{condition}}} {
+    path = {{{path}}};
+  }{{/diverged_paths}}
+  {{/paths_are_uniform}}
   const method = {{{http_verb}}};
   {{^body_required}}
   body = body || '';

--- a/api_generator/src/spec_parser/ApiFunction.ts
+++ b/api_generator/src/spec_parser/ApiFunction.ts
@@ -11,6 +11,7 @@
 import _ from 'lodash'
 import type { Parameter, RequestBody, ResponseBody, Operation } from './types'
 import { to_pascal_case } from '../helpers'
+import ApiPath from './ApiPath'
 
 export interface ApiFunctionTyping {
   request: string
@@ -25,7 +26,7 @@ export default class ApiFunction {
   readonly ns_prototype: string
   readonly name: string
   readonly full_name: string
-  readonly url: string
+  readonly paths: ApiPath[]
   readonly http_verbs: Set<string>
   readonly description: string
   readonly api_reference: string | undefined
@@ -44,7 +45,7 @@ export default class ApiFunction {
     this.name = operations[0].group
     this.full_name = operations[0].full_name
     this.ns_prototype = ns_prototype
-    this.url = _.maxBy(operations, (o) => o.url.split('/').length)?.url ?? ''
+    this.paths = ApiPath.from_operations(operations)
     this.path_params = this.#path_params(operations)
     this.query_params = this.#query_params(operations)
     this.http_verbs = new Set(operations.map((o) => o.http_verb.toUpperCase()))

--- a/api_generator/src/spec_parser/ApiPath.ts
+++ b/api_generator/src/spec_parser/ApiPath.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+import _ from 'lodash'
+import { type Operation } from './types'
+
+export default class ApiPath {
+  readonly url: string
+  readonly components: string[]
+  readonly params: string[]
+  readonly param_signature: string
+  readonly static_signature: string
+
+  constructor (url: string) {
+    this.url = url
+    this.components = this.#components()
+    this.params = this.components.filter(x => !x.startsWith("'"))
+    this.param_signature = _.clone(this.params).sort().join()
+    this.static_signature = this.components.filter(x => x.startsWith("'"))
+      .map(x => x.replaceAll("'", ''))
+      .join('/')
+  }
+
+  static from_operations (operations: Operation[]): ApiPath[] {
+    const paths = operations.map(o => new ApiPath(o.url))
+    return _.uniqBy(paths, 'param_signature')
+  }
+
+  // Operations with statically uniform paths can be grouped together in a simple one-line path constructor
+  // Operations with diverged paths will require a more complex path constructor with multiple if-else branches
+  static statically_uniform (paths: ApiPath[]): boolean {
+    return _.uniqBy(paths, 'static_signature').length === 1
+  }
+
+  // Generate a path constructor
+  // @param required - whether all path parameters are required
+  build (required: boolean): string {
+    if (this.components.length === 0) return "'/'"
+    return required ? this.#build_required() : this.#build_optional()
+  }
+
+  // turn ['one', a, b, 'two/three', c] into '/one' + a + '/' + b + '/two/three/' + c
+  // turn [a, b, 'one', c] into '/' + a + '/' + b + '/one/' + c
+  #build_required (): string {
+    const components = this.components.map(x => !x.startsWith("'") ? x : `'/${x.slice(1, -1)}/'`)
+    if (!components[0].startsWith("'")) components.unshift("'/'")
+    const next = _.clone(components)
+    next.shift()
+    next.push("'^.^'") // sentinel value to mark the end of the array
+    return Array.from({ length: components.length }, (_, i) => [components[i], next[i]])
+      .flatMap(([com, nxt]) => {
+        if (!com.startsWith("'") && !nxt.startsWith("'")) return [com, "'/'"] // insert '/' between param components
+        if (com.startsWith("'") && nxt === "'^.^'") return `${com.slice(0, -2)}'` // remove trailing '/' from last component
+        return com
+      }).join(' + ')
+  }
+
+  // turn ['one', a, b, 'two/three', c] into `['/one', a, b, 'two/three', c].filter(c => c).join('/')`
+  // turn [a, b, 'one', c] into `['', a, b, 'one', c].filter(c => c).join('/')`
+  #build_optional (): string {
+    const components = _.clone(this.components)
+    if (components[0].startsWith("'")) components[0] = `'/${components[0].slice(1)}`
+    else components.unshift("''")
+    return `[${components.join(', ')}].filter(c => c).join('/')`
+  }
+
+  // turn '/one/{a}/{b}/two/three/{c}' into ['one', a, b, 'two/three', c]
+  #components (): string[] {
+    return this.url
+      .split('{').flatMap(x => x.split('}'))
+      .map(x => {
+        if (!x.includes('/')) return x // path parameter
+        if (x.startsWith('/')) x = x.slice(1) // remove leading '/' of static component
+        if (x.endsWith('/')) x = x.slice(0, -1) // remove trailing '/' of static component
+        return `'${x}'` // static component
+      })
+      .filter(x => x !== '' && x !== "''")
+  }
+}


### PR DESCRIPTION
## Handling of more complex sets of URLs.

Previously, the api_generator assumed that all URL paths of the same `x-operation-group` shared the same static components (i.e. if you remove all `{path_param}` components in each path, the paths are identical):
For example these 4 paths of the `nodes.stats` group have an identical set of static components of `_nodes` and `stats`
- /_nodes/{node_id}/stats/{metric}/{index_metric}
- /_nodes/{node_id}/stats/{metric}
- /_nodes/{node_id}/stats
- /_nodes/stats

And the generator would build the path as
```ts
const path = ['/_nodes/', node_id, '/stats/', metric, '/', index_metric].filter(c => c).join('').replace('//', '/');
```
However this assumption not true for some operation groups like `cluster.stats`:
- /_cluster/stats/{metric}/{index_metric}/nodes/{node_id}
- /_cluster/stats/{metric}/nodes/{node_id}
- /_cluster/stats/nodes/{node_id}
- /_cluster/stats

Notice that the first 3 paths have `_cluster`, `stats` and `nodes` as their static components while the last one only has `_cluster` and `stats`. Therefore the following path that the generator use to make is incorrect:
```ts
const path = ['/_cluster/', metric, '/', index_metric, 'stats/nodes/', node_id].filter(c => c).join('').replace('//', '/');
```
because when none of the path params are provided, we would end up with `const path = '/_cluster/states/nodes'`, which is not a valid path. With this PR, the generator will be able to detect this edge case and generate a more complex path building strategy for `cluster.stats`:
```ts
let path;
if (metric != null && index_metric != null && node_id != null) {
  path = '/_cluster/stats/' + metric + '/' + index_metric + '/nodes/' + node_id;
}  else if (metric != null && node_id != null) {
  path = '/_cluster/stats/' + metric + '/nodes/' + node_id;
}  else if (node_id != null) {
  path = '/_cluster/stats/nodes/' + node_id;
}  else {
  path = '/_cluster/stats';
}
```
## Streamlined path building code
The generated path building logic for operation groups with uniform static path components is now simpler and more performant. Here are a few examples of old vs new code:
```ts
const path = ['/_nodes/', node_id, '/stats/', metric, '/', index_metric].filter(c => c).join('').replace('//', '/');
const path = ['/_nodes', node_id, 'stats', metric, index_metric].filter(c => c).join('/');
```
```ts
const path = ['/', index, '/_alias/', name].filter(c => c).join('').replace('//', '/');
const path = ['', index, '_alias', name].filter(c => c).join('/');
```
```ts
const path = ['/', index, '/_validate/query'].filter(c => c).join('').replace('//', '/');
const path = ['', index, '_validate/query'].filter(c => c).join('/');
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
