### PR TITLE
Fixed path component filter

### DIFF
--- a/api/utils.js
+++ b/api/utils.js
@@ -35,7 +35,7 @@ const kConfigErr = Symbol('configuration error');
 function noop() {}
 
 function parsePathParam(param) {
-  if (param == null) return null;
+  if (param == null || param === '') return null;
   return encodeURIComponent(param);
 }
 

--- a/api_generator/src/spec_parser/ApiPath.ts
+++ b/api_generator/src/spec_parser/ApiPath.ts
@@ -62,13 +62,13 @@ export default class ApiPath {
       }).join(' + ')
   }
 
-  // turn ['one', a, b, 'two/three', c] into `['/one', a, b, 'two/three', c].filter(c => c).join('/')`
-  // turn [a, b, 'one', c] into `['', a, b, 'one', c].filter(c => c).join('/')`
+  // turn ['one', a, b, 'two/three', c] into `['/one', a, b, 'two/three', c].filter(c => c != null).join('/')`
+  // turn [a, b, 'one', c] into `['', a, b, 'one', c].filter(c => c != null).join('/')`
   #build_optional (): string {
     const components = _.clone(this.components)
     if (components[0].startsWith("'")) components[0] = `'/${components[0].slice(1)}`
     else components.unshift("''")
-    return `[${components.join(', ')}].filter(c => c).join('/')`
+    return `[${components.join(', ')}].filter(c => c != null).join('/')`
   }
 
   // turn '/one/{a}/{b}/two/three/{c}' into ['one', a, b, 'two/three', c]


### PR DESCRIPTION
JS considers `''` to be false. Updating the filter to include blank strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
