### PR TITLE
fix: revert Search_Response

### DIFF
--- a/api/_core/search.d.ts
+++ b/api/_core/search.d.ts
@@ -106,9 +106,8 @@ export type Search_RequestBody = {
   version?: boolean;
 }
 
-export type Search_Response = ApiResponse & {
+export interface Search_Response extends ApiResponse {
   body: Search_ResponseBody;
 }
 
 export type Search_ResponseBody = Core_Search.ResponseBody
-


### PR DESCRIPTION
Reverted a change between `beta.7` and `beta.8` that broke the Search_Response typings.

Closes https://github.com/opensearch-project/opensearch-js/issues/942