### PR TITLE
Skipping new nodes which do not have the http property present yet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Updated API to match the OpenSearch spec from Feb 11, 2025
 ### Fixed
-- Skip nodes that are not ready ready yet ([#984](https://github.com/opensearch-project/opensearch-js/issues/984))
+- Skip nodes that are not ready yet ([#984](https://github.com/opensearch-project/opensearch-js/issues/984))
 
 ## [3.2.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [3.3.0]
 ### Changed
 - Updated API to match the OpenSearch spec from Feb 11, 2025
+### Fixed
+- Skip nodes that are not ready ready yet ([#984](https://github.com/opensearch-project/opensearch-js/issues/984))
 
 ## [3.2.0]
 ### Changed

--- a/lib/pool/BaseConnectionPool.js
+++ b/lib/pool/BaseConnectionPool.js
@@ -222,6 +222,12 @@ class BaseConnectionPool {
 
     for (let i = 0, len = ids.length; i < len; i++) {
       const node = nodes[ids[i]];
+
+      // New nodes do not have the http property populated yet. Skip this for now.
+      if (node.http === undefined) {
+        continue;
+      }
+
       // If there is no protocol in
       // the `publish_address` new URL will throw
       // the publish_address can have two forms:

--- a/test/unit/base-connection-pool.test.js
+++ b/test/unit/base-connection-pool.test.js
@@ -654,8 +654,6 @@ test('API', (t) => {
       },
     ]);
 
-    t.equal(pool.nodesToHost(nodes, 'http:').length, 1);
-    t.equal(pool.nodesToHost(nodes, 'http:')[0].url.host, '127.0.0.1:9200');
     t.end();
   });
 

--- a/test/unit/base-connection-pool.test.js
+++ b/test/unit/base-connection-pool.test.js
@@ -628,5 +628,36 @@ test('API', (t) => {
     }
   });
 
+  t.test('Should skip nodes when the http property is undefined', (t) => {
+    const pool = new BaseConnectionPool({ Connection });
+    const nodes = {
+      a1: {
+        http: {
+          publish_address: '127.0.0.1:9200',
+        },
+        roles: ['master', 'data', 'ingest'],
+      },
+      a2: {
+        roles: ['master', 'data', 'ingest'],
+      },
+    };
+
+    t.same(pool.nodesToHost(nodes, 'http:'), [
+      {
+        url: new URL('http://127.0.0.1:9200'),
+        id: 'a1',
+        roles: {
+          master: true,
+          data: true,
+          ingest: true,
+        },
+      },
+    ]);
+
+    t.equal(pool.nodesToHost(nodes, 'http:').length, 1);
+    t.equal(pool.nodesToHost(nodes, 'http:')[0].url.host, '127.0.0.1:9200');
+    t.end();
+  });
+
   t.end();
 });


### PR DESCRIPTION
### Description

New nodes do not necessarily have the `http` property present. Skipping these nodes to avoid issues where the property is accessed.

### Issues Resolved

https://github.com/opensearch-project/opensearch-js/issues/984

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
