### PR TITLE
Api Generator: API functions that perform `HEAD` requests now return boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Dependencies
 ### Changed
+- Api Generator: API functions that perform `HEAD` requests now return boolean values instead of the response body
 ### Deprecated
 ### Removed
 ### Fixed

--- a/api_generator/src/renderers/render_types/FunctionTypesContainer.ts
+++ b/api_generator/src/renderers/render_types/FunctionTypesContainer.ts
@@ -53,6 +53,7 @@ export default class FunctionTypesContainer extends TypesContainer {
   }
 
   #build_response (): Schema {
+    if (this._func.http_verbs.has('HEAD')) return { type: 'boolean' }
     const schema = { properties: { body: { $ref: this.create_ref('response_body') } }, required: ['body'] }
     return { allOf: [schema, { $ref: 'ApiResponse' }] }
   }


### PR DESCRIPTION
### Description

Fixing https://github.com/opensearch-project/opensearch-js/issues/990
(That issue will be closed by the next automated API Update PR)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
