### PR TITLE
Fixing bugs in API Generator

### DIFF
--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -21,7 +21,7 @@ jobs:
         entry:
           - { node_version: '18.x', opensearch_ref: '1.x', jdk_version: '11' }
           - { node_version: '18.x', opensearch_ref: '2.x', jdk_version: '17' }
-          - { node_version: '18.x', opensearch_ref: 'main', jdk_version: '21' }
+          - { node_version: '18.x', opensearch_ref: 'main', jdk_version: '17' }
     steps:
       - name: Checkout OpenSearch
         uses: actions/checkout@v4

--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -21,7 +21,7 @@ jobs:
         entry:
           - { node_version: '18.x', opensearch_ref: '1.x', jdk_version: '11' }
           - { node_version: '18.x', opensearch_ref: '2.x', jdk_version: '17' }
-          - { node_version: '18.x', opensearch_ref: 'main', jdk_version: '17' }
+          - { node_version: '18.x', opensearch_ref: 'main', jdk_version: '21' }
     steps:
       - name: Checkout OpenSearch
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Api Generator: API functions that perform `HEAD` requests now return boolean values instead of the response body ([#993](https://github.com/opensearch-project/opensearch-js/pull/993))
+- Api Generator: Account for oneOf nested within AllOf ([#993](https://github.com/opensearch-project/opensearch-js/pull/993))
 ### Security
 
 ## [3.4.0]

--- a/api_generator/src/renderers/BaseRenderer.ts
+++ b/api_generator/src/renderers/BaseRenderer.ts
@@ -22,10 +22,10 @@ export default class BaseRenderer {
     throw Error('Not implemented')
   }
 
-  render (template_path?: string, view?: Record<string, any>): string {
-    const full_path = path.join(__dirname, './templates', template_path ?? this.template_file)
+  render (args: { template_path?: string, view?: Record<string, any> } = {}): string {
+    const full_path = path.join(__dirname, './templates', args.template_path ?? this.template_file)
     const template = fs.readFileSync(full_path, 'utf8')
-    view = view ?? this.view()
+    const view = args.view ?? this.view()
     return Mustache.render(template, { ...this.#commons(), ...view }, this.#partials())
   }
 

--- a/api_generator/src/renderers/render_types/FunctionTypesContainer.ts
+++ b/api_generator/src/renderers/render_types/FunctionTypesContainer.ts
@@ -53,6 +53,7 @@ export default class FunctionTypesContainer extends TypesContainer {
   }
 
   #build_response (): Schema {
+    if (this._func.http_verbs.has('HEAD')) return { type: 'boolean' }
     const schema = { properties: { body: { $ref: this.create_ref('response_body') } }, required: ['body'] }
     return { allOf: [schema, { $ref: 'ApiResponse' }] }
   }

--- a/api_generator/src/renderers/render_types/TypesContainer.ts
+++ b/api_generator/src/renderers/render_types/TypesContainer.ts
@@ -46,7 +46,7 @@ export default class TypesContainer {
     return TypesContainer.import_path(from, this)
   }
 
-  ref_to_obj (ref: string): string {
+  ref_to_imported_type (ref: string): string {
     if (ref === 'ApiResponse') return ref
     const schema_name = ref.split(SEPARATOR)[1]
     const container = this.ref_to_container(ref)
@@ -55,7 +55,7 @@ export default class TypesContainer {
   }
 
   ref_to_container (ref: string): TypesContainer {
-    let file_path: string = 'UNSET'
+    let file_path: string
     if (ref.startsWith('#/components')) {
       const file_name = ref.split(SEPARATOR)[0].split('/').reverse()[0]
       file_path = path.join(TYPE_COMPONENTS_FOLDER, `${file_name}.d.ts`)


### PR DESCRIPTION
## --- Note that this also involves some refactoring to tidy things up. The actual changes are pretty small ---

### Accounting for oneOf within allOf when rendering types (related to #977)
```ts
export type DistanceFeatureQuery = QueryBase & Record<string, any> 
```
will become
```ts
export type DistanceFeatureQuery = QueryBase & {
  field: Common.Field;
  origin: Common.GeoLocation;
  pivot: Common.Distance;
} | {
  field: Common.Field;
  origin: Common.DateMath;
  pivot: Common.Duration;
}
```
---
### `HEAD` requests now return boolean values instead of the response body (fixing #992)
```ts
export interface Indices_ExistsAlias_Response extends ApiResponse {
  body: Indices_ExistsAlias_ResponseBody;
}
```
will become
```ts
export type Indices_ExistsAlias_Response = boolean
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
