### PR TITLE
[api_generator] Added parentheses around unions nested within intersections and vice versa.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,19 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+### Security
+
+## [3.5.0]
+### Added
+### Dependencies
+### Changed
+- Updated API to match the OpenSearch spec from April 02, 2025
+### Deprecated
+### Removed
+### Fixed
 - Api Generator: API functions that perform `HEAD` requests now return boolean values instead of the response body ([#993](https://github.com/opensearch-project/opensearch-js/pull/993))
 - Api Generator: Account for oneOf nested within AllOf ([#993](https://github.com/opensearch-project/opensearch-js/pull/993))
+- Api Generator: Removed duplicated component types within intersection/union types ([#998](https://github.com/opensearch-project/opensearch-js/pull/998))
 ### Security
 
 ## [3.4.0]

--- a/api_generator/src/renderers/render_types/TypesFileRenderder.ts
+++ b/api_generator/src/renderers/render_types/TypesFileRenderder.ts
@@ -90,11 +90,11 @@ export default class TypesFileRenderder extends BaseRenderer {
   }
 
   #union (renders: string[]): string {
-    return renders.map(render => this.#parenthesize(render, ' & ')).join(' | ')
+    return _.uniq(renders.map(render => this.#parenthesize(render, ' & '))).join(' | ')
   }
 
   #intersection (renders: string[]): string {
-    return renders.map(render => this.#parenthesize(render, ' | ')).join(' & ')
+    return _.uniq(renders.map(render => this.#parenthesize(render, ' | '))).join(' & ')
   }
 
   #parenthesize (render: string, token: ' | ' | ' & '): string {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "LICENSE.txt"
   ],
   "homepage": "https://www.opensearch.org/",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "versionCanary": "7.10.0-canary.6",
   "keywords": [
     "opensearch",


### PR DESCRIPTION
Follow up of https://github.com/opensearch-project/opensearch-js/pull/993

BEFORE
```ts
export type DistanceFeatureQuery = QueryBase & {
  field: Common.Field;
  origin: Common.GeoLocation;
  pivot: Common.Distance;
} | {
  field: Common.Field;
  origin: Common.DateMath;
  pivot: Common.Duration;
}
```
AFTER
```ts
export type DistanceFeatureQuery = QueryBase & ({
  field: Common.Field;
  origin: Common.GeoLocation;
  pivot: Common.Distance;
} | {
  field: Common.Field;
  origin: Common.DateMath;
  pivot: Common.Duration;
})
```

---

BEFORE
```ts
export type RangeQuery = RangeQueryBase & NumberRangeQueryParameters | DateRangeQueryParameters
```
AFTER
```ts
export type RangeQuery = RangeQueryBase & (NumberRangeQueryParameters | DateRangeQueryParameters)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
