### PR TITLE
Add Error Listener Back Before Calback 

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -112,6 +112,8 @@ class Connection {
     const onResponse = (response) => {
       cleanListeners();
       this._openRequests--;
+      // re-add an error listener
+      request.addListener('error', (err) => {console.log('ignoring error after response', err)});
       callback(null, response);
     };
 


### PR DESCRIPTION
### Description

Thanks @ananzh for the following investigation.

In the `onResponse()` function in `Connection.js`, `cleanListeners()` removes all event listeners from the request, including the error listener.

```
function cleanListeners() {
  request.removeListener('response', onResponse);
  request.removeListener('timeout', onTimeout);
  request.removeListener('error', onError);
  request.removeListener('abort', onAbort);
  cleanedListeners = true;
}
```
After the response is handled and the listeners are removed, the remainder of the request body tries to write to the now-closed connection
This triggers an error event on the request object
Since there are no error listeners attached to the request (they were removed by cleanListeners()), this becomes an uncaught exception that crashes the Node.js process

By adding the error listener back, we are able to keep an error listener on the request in the event that the response comes back before the entire request is sent.


### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
