### PR TITLE
Add skip_existing property

### DIFF
--- a/api/_types/ingest._common.d.ts
+++ b/api/_types/ingest._common.d.ts
@@ -270,6 +270,7 @@ export type TextEmbeddingProcessor = ProcessorBase & {
   batch_size?: number;
   field_map: Record<string, string>;
   model_id: Common.Id;
+  skip_existing?: boolean;
 }
 
 export type TrimProcessor = ProcessorBase & {


### PR DESCRIPTION
### Description

Adds missing `skip_existing` property to TextEmbeddingProcessor type

### Issues Resolved

https://github.com/opensearch-project/opensearch-js/issues/1057

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [X] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
