### PR TITLE
feat: add host header overwrite

### DIFF
--- a/lib/aws/shared.js
+++ b/lib/aws/shared.js
@@ -52,7 +52,7 @@ function giveAwsV4Signer(awsDefaultCredentialsProvider) {
       request.service = opts.service;
       request.region = opts.region;
       request.headers = request.headers || {};
-      request.headers['host'] = request.hostname;
+      request.headers['host'] = request.headers['host'] || request.hostname;
 
       if (request['auth']) {
         const awssigv4Cred = request['auth'];

--- a/test/unit/lib/aws/awssigv4signer.test.js
+++ b/test/unit/lib/aws/awssigv4signer.test.js
@@ -123,6 +123,44 @@ test('Sign with SigV4 and provided service', (t) => {
   t.same(signedRequest.service, mockService);
 });
 
+test('Sign with SigV4 preserves user-provided host header', (t) => {
+  t.plan(1);
+
+  const mockCreds = {
+    accessKeyId: uuidv4(),
+    secretAccessKey: uuidv4(),
+  };
+
+  const mockRegion = 'us-west-2';
+
+  const AwsSigv4SignerOptions = {
+    getCredentials: () =>
+      new Promise((resolve) => {
+        setTimeout(() => resolve(mockCreds), 100);
+      }),
+    region: mockRegion,
+  };
+
+  const auth = AwsSigv4Signer(AwsSigv4SignerOptions);
+
+  const connection = new Connection({
+    url: new URL('https://localhost:9200'),
+  });
+
+  const customHost = 'custom.example.com';
+
+  const request = connection.buildRequestObject({
+    path: '/hello',
+    method: 'GET',
+    headers: {
+      host: customHost,
+    },
+  });
+
+  const signedRequest = auth.buildSignedRequestObject(request);
+  t.same(signedRequest.headers.host, customHost, 'host header should be overwritable via headers');
+});
+
 test('Sign with SigV4 using default getCredentials provider', (t) => {
   t.plan(2);
 


### PR DESCRIPTION
### Description

Previous behavior overwrote Host header to the hostname. But in multi VPC deployments where the client communicates with the Opensearch domain through a managed VPC connection, the domain's InvalidHostHeaderRequests metric shows that these requests are registered as invalid host header requests.

### Issues Resolved

#1089

### Check List

- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
