### PR TITLE
Fix x-amz-content-sha256 header not being signed in SigV4

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -21,10 +21,12 @@ jobs:
         entry:
           - { opensearch_version: 1.1.0 }
           - { opensearch_version: 1.2.4 }
+          - { opensearch_version: 1.3.19 }
           - { opensearch_version: 1.3.20 }
-          - { opensearch_version: 2.3.0 }
+          - { opensearch_version: 2.2.1 }
           - { opensearch_version: 2.6.0 }
           - { opensearch_version: 2.12.0 }
+          - { opensearch_version: 2.16.0 }
           - { opensearch_version: 2.17.0 }
           - { opensearch_version: 2.19.0 }
     env:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -21,12 +21,12 @@ jobs:
         entry:
           - { opensearch_version: 1.1.0 }
           - { opensearch_version: 1.2.4 }
-          - { opensearch_version: 1.3.19 }
-          - { opensearch_version: 2.2.1 }
+          - { opensearch_version: 1.3.20 }
+          - { opensearch_version: 2.3.0 }
           - { opensearch_version: 2.6.0 }
           - { opensearch_version: 2.12.0 }
-          - { opensearch_version: 2.16.0 }
           - { opensearch_version: 2.17.0 }
+          - { opensearch_version: 2.19.0 }
     env:
       OPENSEARCH_VERSION: ${{ matrix.entry.opensearch_version }}
       SECURE_INTEGRATION: ${{ matrix.secured }}

--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -49,7 +49,7 @@ jobs:
         if: steps.cache-restore.outputs.cache-hit != 'true'
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.entry.jdk_version || '17' }}
+          java-version: ${{ matrix.entry.jdk_version || '21' }}
 
       - name: Assemble OpenSearch
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Get OpenSearch branch top
         id: get-key
         working-directory: opensearch
-        run: echo key=`git log -1 --format='%H'` >> $GITHUB_OUTPUT
+        run: |
+          keytemp=`git log -1 --format='%H'`-${{ matrix.entry.opensearch_ref }}
+          echo "key=$keytemp" >> $GITHUB_OUTPUT
 
       - name: Restore cached build
         id: cache-restore

--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: Setup Java JDK
         uses: actions/setup-java@v4
-        if: steps.cache-restore.outputs.cache-hit != 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.entry.jdk_version || '21' }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
-        os: [ubuntu-latest, windows-latest, macOS-13]
+        os: [ubuntu-latest, windows-latest, macos-15]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
-        os: [ubuntu-latest, windows-latest, macos-15]
+        os: [ubuntu-latest, windows-latest, macos-15-intel]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [3.6.0]
 ### Fixed
 - Fix `x-amz-content-sha256` not included in SigV4 SignedHeaders ([#1098](https://github.com/opensearch-project/opensearch-js/issues/1098), ([#1099](https://github.com/opensearch-project/opensearch-js/pull/1099)))
+- chore: Replace pinned @sinonjs/fake-timers commit with ^15.3.2 ([#1100](https://github.com/opensearch-project/opensearch-js/pull/1100))
 
 ## [3.5.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
-
-- Fix `x-amz-content-sha256` not included in SigV4 SignedHeaders ([#1098](https://github.com/opensearch-project/opensearch-js/issues/1098))
-
 ### Security
+
+## [3.6.0]
+### Fixed
+- Fix `x-amz-content-sha256` not included in SigV4 SignedHeaders ([#1098](https://github.com/opensearch-project/opensearch-js/issues/1098), ([#1099](https://github.com/opensearch-project/opensearch-js/pull/1099)))
 
 ## [3.5.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fix `x-amz-content-sha256` not included in SigV4 SignedHeaders ([#1098](https://github.com/opensearch-project/opensearch-js/issues/1098))
+
 ### Security
 
 ## [3.5.1]

--- a/lib/aws/shared.js
+++ b/lib/aws/shared.js
@@ -65,11 +65,12 @@ function giveAwsV4Signer(awsDefaultCredentialsProvider) {
         request.service = awssigv4Cred.service;
         delete request['auth'];
       }
-      const signed = aws4.sign(request, credentialsState.credentials);
-      signed.headers['x-amz-content-sha256'] = crypto
+
+      request.headers['x-amz-content-sha256'] = crypto
         .createHash('sha256')
         .update(request.body || '', 'utf8')
         .digest('hex');
+      const signed = aws4.sign(request, credentialsState.credentials);
       return signed;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensearch-project/opensearch",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensearch-project/opensearch",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "aws4": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "LICENSE.txt"
   ],
   "homepage": "https://www.opensearch.org/",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "versionCanary": "7.10.0-canary.6",
   "keywords": [
     "opensearch",

--- a/test/unit/lib/aws/awssigv4signer.test.js
+++ b/test/unit/lib/aws/awssigv4signer.test.js
@@ -19,7 +19,7 @@ const { debug } = require('console');
 const { RequestAbortedError } = require('../../../../lib/errors');
 
 test('Sign with SigV4', (t) => {
-  t.plan(4);
+  t.plan(6);
 
   const mockCreds = {
     accessKeyId: uuidv4(),
@@ -58,6 +58,14 @@ test('Sign with SigV4', (t) => {
     'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
   );
   t.same(signedRequest.service, 'es');
+
+  const authHeader = signedRequest.headers['Authorization'];
+  const signedHeadersMatch = authHeader.match(/SignedHeaders=([^,]+)/);
+  t.ok(signedHeadersMatch, 'Authorization header contains SignedHeaders');
+  t.ok(
+    signedHeadersMatch[1].includes('x-amz-content-sha256'),
+    'x-amz-content-sha256 is included in SignedHeaders'
+  );
 });
 
 test('Sign with SigV4 failure (with empty region)', (t) => {


### PR DESCRIPTION
### Description

_Describe what this change achieves._

Fix `x-amz-content-sha256` header not being included in SigV4 SignedHeaders when using AwsSigv4Signer.

Previously, the x-amz-content-sha256 header was set on the request after aws4.sign() was called in 
`shared.js`. This meant the header was present on the wire but not included in the SignedHeaders list of the Authorization header. 

In OpenSearch Serverless, it will require `x-amz-content-sha256` to be signed, following the AWS recommendation that all headers with `x-amz-*` format should be signed. 

Reference - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
> "You must include the host header and any x-amz-* headers in the signature."


Without this fix, the request to Opensearch Serverless would return  a 400 error: `x-amz-content-sha256 header must be signed in SigV4`.

The fix moves the x-amz-content-sha256 assignment before the aws4.sign() call so it is included in the signature computation.

### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

https://github.com/opensearch-project/opensearch-js/issues/1098

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [] Linter check was successfull - `yarn run lint` doesn't show any errors 
    - errors are unrelated to my change 
- [X] Commits are signed per the DCO using --signoff
- [X] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
