### PR TITLE
[api_generator] Add parentheses around array element types containing intersections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Api Generator: fix invalid extends syntax generated for nested allOf inside object properties ([#1128](https://github.com/opensearch-project/opensearch-js/pull/1128))
+- Api Generator: Add parentheses around array element types containing intersections, fixing the `HitsMetadata.hits` type ([#1112](https://github.com/opensearch-project/opensearch-js/issues/1112))
 ### Security
 
 ## [3.6.0]

--- a/api/_types/_core.search.d.ts
+++ b/api/_types/_core.search.d.ts
@@ -253,9 +253,9 @@ export type Hit = {
 }
 
 export type HitsMetadata = {
-  hits: Hit & {
+  hits: (Hit & {
   _source?: T;
-}[];
+})[];
   max_score?: undefined | number;
   total?: TotalHits | number;
 }

--- a/api_generator/src/renderers/render_types/TypesFileRenderder.ts
+++ b/api_generator/src/renderers/render_types/TypesFileRenderder.ts
@@ -45,7 +45,7 @@ export default class TypesFileRenderder extends BaseRenderer {
     if (Array.isArray(schema.items)) throw new Error('Unhandled positioned array schema')
     if (_.isEmpty(schema)) return 'any'
     if (schema.$ref != null) return this._container.ref_to_imported_type(schema.$ref)
-    if (schema.items != null) return `${this.#render_schema(schema.items as Schema)}[]`
+    if (schema.items != null) return `${this.#parenthesize(this.#render_schema(schema.items as Schema), [' & ', ' | '])}[]`
     if (schema.type === 'array') return 'any[]'
     if (schema.enum != null) return schema.enum.map(str => `'${str as string}'`).join(' | ')
     if (schema.type === 'string' && schema.const != null) return `'${schema.const as string}'`
@@ -90,15 +90,15 @@ export default class TypesFileRenderder extends BaseRenderer {
   }
 
   #union (renders: string[]): string {
-    return _.uniq(renders.map(render => this.#parenthesize(render, ' & '))).join(' | ')
+    return _.uniq(renders.map(render => this.#parenthesize(render, [' & ']))).join(' | ')
   }
 
   #intersection (renders: string[]): string {
-    return _.uniq(renders.map(render => this.#parenthesize(render, ' | '))).join(' & ')
+    return _.uniq(renders.map(render => this.#parenthesize(render, [' | ']))).join(' & ')
   }
 
-  #parenthesize (render: string, token: ' | ' | ' & '): string {
-    const required = !render.startsWith('(') && _.some(render.split('\n').map(line => line.includes(token) && !line.endsWith(';')))
+  #parenthesize (render: string, tokens: Array<' | ' | ' & '>): string {
+    const required = !render.startsWith('(') && _.some(render.split('\n').map(line => tokens.some(token => line.includes(token)) && !line.endsWith(';')))
     return required ? `(${render})` : render
   }
 


### PR DESCRIPTION
### Description

`HitsMetadata.hits` is generated as `Hit & { _source?: T; }[]`. TypeScript parses this as `Hit & ({ _source?: T; }[])` because `[]` binds tighter than `&`, which makes `hits[0]._id` unreachable and surfaces `_source` on the array itself instead of its elements.

The `#parenthesize` helper in `TypesFileRenderder` only guarded against `&`/`|` operator collisions; it did nothing when an intersection appeared as the `items` schema of an array. Generalized it to accept multiple tokens and applied it at the array-postfix site.

BEFORE
```ts
export type HitsMetadata = {
  hits: Hit & {
    _source?: T;
  }[];
  ...
}
```

AFTER
```ts
export type HitsMetadata = {
  hits: (Hit & {
    _source?: T;
  })[];
  ...
}
```

### Issues Resolved

Closes #1112

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] Linter check was successfull - `yarn run lint` doesn't show any errors
- [x] Commits are signed per the DCO using --signoff
- [x] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
