### PR TITLE
Fix type generator operator precedence for array of intersection/union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Api Generator: fix TypeScript operator precedence when wrapping intersection/union types in arrays (e.g. `Hit & { _source?: TDocument; }[]` now renders as `(Hit & { _source?: TDocument; })[]`)
 ### Security
 
 ## [3.6.0]

--- a/api_generator/src/renderers/render_types/TypesFileRenderder.ts
+++ b/api_generator/src/renderers/render_types/TypesFileRenderder.ts
@@ -45,7 +45,7 @@ export default class TypesFileRenderder extends BaseRenderer {
     if (Array.isArray(schema.items)) throw new Error('Unhandled positioned array schema')
     if (_.isEmpty(schema)) return 'any'
     if (schema.$ref != null) return this._container.ref_to_imported_type(schema.$ref)
-    if (schema.items != null) return `${this.#render_schema(schema.items as Schema)}[]`
+    if (schema.items != null) return `${this.#parenthesize_for_array(this.#render_schema(schema.items as Schema))}[]`
     if (schema.type === 'array') return 'any[]'
     if (schema.enum != null) return schema.enum.map(str => `'${str as string}'`).join(' | ')
     if (schema.type === 'string' && schema.const != null) return `'${schema.const as string}'`
@@ -99,6 +99,12 @@ export default class TypesFileRenderder extends BaseRenderer {
 
   #parenthesize (render: string, token: ' | ' | ' & '): string {
     const required = !render.startsWith('(') && _.some(render.split('\n').map(line => line.includes(token) && !line.endsWith(';')))
+    return required ? `(${render})` : render
+  }
+
+  #parenthesize_for_array (render: string): string {
+    if (render.startsWith('(')) return render
+    const required = _.some(render.split('\n').map(line => (line.includes(' & ') || line.includes(' | ')) && !line.endsWith(';')))
     return required ? `(${render})` : render
   }
 


### PR DESCRIPTION
## Description

When an `allOf` schema appears as the `items` of an `array` schema, `TypesFileRenderder` previously appended `[]` directly to the intersection render. Because `[]` binds tighter than `&`/`|` in TypeScript, the result is invalid and silently collapses the intersection.

## How this surfaced

A downstream project (`dfinitiv/savvy-core`) upgraded `@opensearch-project/opensearch` from `3.5.1` → `3.6.0` and TypeScript started rejecting code that read `hit.sort`, `hit._id`, etc. from a search response — see [dfinitiv/savvy-core#92 (comment)](https://github.com/dfinitiv/savvy-core/pull/92#issuecomment-4373659649). Comparing the generated `api/_types/_core.search.d.ts` between releases pinpoints the regression:

**3.5.1 (correct):**
```ts
export type HitsMetadata = {
  hits: Hit[];
  ...
}
```

**3.6.0 (broken):**
```ts
export type HitsMetadata = {
  hits: Hit & {
    _source?: TDocument;
  }[];
  ...
}
```

Between 3.5.1 and 3.6.0 the OpenAPI spec was updated to make `Hit._source` reference the new `TDocument` generic-parameter schema (a desirable change). The regeneration produced the second form, which TypeScript parses as `Hit & ({ _source?: TDocument; })[]` due to operator precedence: `[]` binds tighter than `&`/`|`. The intersection of `Hit` with an array type collapses to the array type, so every other property of `Hit` (`sort`, `_id`, `_score`, ...) silently disappears and downstream `Search_ResponseBody`-consuming code can no longer access them. This is a real regression in 3.6.0, not loose user code.

## Fix

Wrap the items render in parentheses when it contains a top-level `&` or `|`:

```ts
export type HitsMetadata = {
  hits: (Hit & {
    _source?: TDocument;
  })[];
  ...
}
```

Same correction also applies to a handful of other generated types whose `items` resolved to a union or intersection (e.g. `CompletionSuggest.options`, `Suggest`).

## Verification

- Ran `npm run download_spec && npm run generate_api` and diffed `api/_types/_core.search.d.ts`:
  - Before: `hits: Hit & { _source?: TDocument; }[];`
  - After: `hits: (Hit & { _source?: TDocument; })[];`
- `npm run lint` clean in `api_generator/`.
- `npx tsd` is currently blocked by an unrelated, pre-existing bug in `api/_core/explain.d.ts` (`extends Common.InlineGet { ... }` emitted inside a property), which is out of scope for this PR.

## Issues Resolved

Partial mitigation for the 3.6.0 type regression around `HitsMetadata`/`Hit`. The `_source` field still resolves to `Record<string, any>` (the declared shape of `TDocument`) rather than a user-supplied generic parameter — that is a separate, larger change in the generator.

## Check List

- [x] New functionality includes testing.  *(generator has no test suite; regeneration of the spec exercises the change)*
- [x] All tests pass.  *(lint passes; pre-existing `tsd` failure unrelated)*
- [x] Commits are signed per the DCO using --signoff.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).