### PR TITLE
Add GitHub environment to release workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Draft a release
+name: Release Workflow
 
 on:
   push:
@@ -6,34 +6,27 @@ on:
       - "*"
 
 jobs:
-  build:
+  release-to-npm:
+    environment: release-approval
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for OIDC
       contents: write
-      issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - id: get_data
-        run: |
-          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-          echo "version=$(cat package.json | jq .version | tr -d "\"")" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_data.outputs.approvers }}
-          minimum-approvals: 1
-          issue-title: 'Release opensearch-js : ${{ steps.get_data.outputs.version }}'
-          issue-body: "Please approve or deny the release of opensearch-js. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
-          exclude-workflow-initiator-as-approver: true
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - run: npm ci
+
       - run: npm publish
-      - name: Release
+
+      - name: Create a release
         uses: softprops/action-gh-release@v2
         with:
           draft: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,8 +34,7 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
 
 1. Create a tag, e.g. v2.1.0, and push it to the GitHub repo.
-1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and is responsible for drafting a new release on GitHub.
-1. Before creating a release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). See sample [issue](https://github.com/gaiksaya/opensearch-js/issues/1). The maintainers need to approve in order to continue the workflow run.
-1. Since the repo is already added as part of NPM trusted publisher, `npm publish` with npm version v11.5.1 or above will directly authenticate the workflow and publish to NPM.
-1. Once the above release workflow is successful, the release on GitHub is published automatically.
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and is responsible for publishing the package to NPM and creating a release on GitHub.
+1. The workflow requires approval from reviewers configured in the `release-approval` GitHub environment before it proceeds.
+1. Once approved, the workflow publishes to NPM using trusted publishers (OIDC authentication) and creates a GitHub release with auto-generated release notes.
 1. Increment "version" in package.json to the next patch release, e.g. v2.1.1. See [example](https://github.com/opensearch-project/opensearch-js/pull/318)


### PR DESCRIPTION
### Description
  - Replaced the manual-approval GitHub Action (issue-based) with a release-approval GitHub environment for release gating.
  - Simplified the workflow by removing unnecessary steps and updating to latest actions (checkout@v6, setup-node@v6).
  - Updated RELEASING.md to document the new environment-based approval process.

### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
