### PR TITLE
fix: handle mixed operations in bulk helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Api Generator: fix invalid extends syntax generated for nested allOf inside object properties ([#1128](https://github.com/opensearch-project/opensearch-js/pull/1128))
 - Replace GitHub App token with opensearch-ci-bot PAT in generate_api workflow ([#1130](https://github.com/opensearch-project/opensearch-js/pull/1130))
 - Api Generator: Lazily instantiate API namespaces to fix Client construction performance ([#1133](https://github.com/opensearch-project/opensearch-js/pull/1133))
+- Fix bulk helper mapping response items to variable-width `bulkBody` when mixing delete and index/create/update operations, which caused incorrect operation/document pairing and undefined deserialization ([#1125](https://github.com/opensearch-project/opensearch-js/issues/1125), [#1126](https://github.com/opensearch-project/opensearch-js/pull/1126))
 ### Security
 - Fix CVEs in diff, lodash, and yaml dependencies ([#1131] https://github.com/opensearch-project/opensearch-js/pull/1131)
 

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -698,20 +698,19 @@ class Helpers {
             setTimeout(tryBulk, wait, bulkBody, retryDocuments);
             return;
           }
-          for (let i = 0, len = bulkBody.length; i < len; i = i + 2) {
-            const operation = Object.keys(serializer.deserialize(bulkBody[i]))[0];
+          let indexSlice = 0;
+          while (indexSlice < bulkBody.length) {
+            const operation = Object.keys(serializer.deserialize(bulkBody[indexSlice]))[0];
             onDrop({
               status: 429,
               error: null,
-              operation: serializer.deserialize(bulkBody[i]),
+              operation: serializer.deserialize(bulkBody[indexSlice]),
               document:
-                operation !== 'delete'
-                  ? serializer.deserialize(bulkBody[i + 1])
-                  : /* istanbul ignore next */
-                    null,
+                operation !== 'delete' ? serializer.deserialize(bulkBody[indexSlice + 1]) : null,
               retried: isRetrying,
             });
             stats.failed += 1;
+            indexSlice += operation !== 'delete' ? 2 : 1;
           }
         }
         callback();
@@ -735,11 +734,11 @@ class Helpers {
             }
             const retry = [];
             const { items } = body;
+            let indexSlice = 0;
             for (let i = 0, len = items.length; i < len; i++) {
               const action = items[i];
               const operation = Object.keys(action)[0];
               const { status } = action[operation];
-              const indexSlice = operation !== 'delete' ? i * 2 : i;
 
               if (status >= 400) {
                 // 429 is the only staus code where we might want to retry
@@ -767,6 +766,7 @@ class Helpers {
               } else {
                 stats.successful += 1;
               }
+              indexSlice += operation !== 'delete' ? 2 : 1;
             }
             callback(null, retry);
           }

--- a/test/unit/helpers/bulk.test.js
+++ b/test/unit/helpers/bulk.test.js
@@ -1228,6 +1228,185 @@ test('bulk delete', (t) => {
   t.end();
 });
 
+test('bulk mixed operations', (t) => {
+  t.test(
+    'Mixed index/delete/index response errors map each failing operation/document correctly',
+    async (t) => {
+      let dropCount = 0;
+      const MockConnection = connection.buildMockConnection({
+        onRequest(params) {
+          t.equal(params.path, '/_bulk');
+          return {
+            body: {
+              took: 0,
+              errors: true,
+              items: [
+                { index: { status: 400, error: { something: 'went wrong' } } },
+                { delete: { status: 400, error: { something: 'went wrong' } } },
+                { index: { status: 400, error: { something: 'went wrong' } } },
+              ],
+            },
+          };
+        },
+      });
+
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: MockConnection,
+      });
+      const result = await client.helpers.bulk({
+        datasource: dataset.slice(),
+        flushBytes: 5000000,
+        concurrency: 1,
+        onDocument(doc) {
+          if (doc.user === 'arya') {
+            return {
+              delete: { _index: 'test', _id: 1 },
+            };
+          }
+          return {
+            index: { _index: 'test' },
+          };
+        },
+        onDrop(doc) {
+          dropCount++;
+          if (dropCount === 1) {
+            t.same(doc, {
+              status: 400,
+              error: { something: 'went wrong' },
+              operation: { index: { _index: 'test' } },
+              document: { user: 'jon', age: 23 },
+              retried: false,
+            });
+          } else if (dropCount === 2) {
+            t.same(doc, {
+              status: 400,
+              error: { something: 'went wrong' },
+              operation: { delete: { _index: 'test', _id: 1 } },
+              document: null,
+              retried: false,
+            });
+          } else if (dropCount === 3) {
+            t.same(doc, {
+              status: 400,
+              error: { something: 'went wrong' },
+              operation: { index: { _index: 'test' } },
+              document: { user: 'tyrion', age: 39 },
+              retried: false,
+            });
+          }
+        },
+      });
+
+      t.equal(dropCount, 3);
+      t.type(result.time, 'number');
+      t.type(result.bytes, 'number');
+      t.match(result, {
+        total: 3,
+        successful: 0,
+        retry: 0,
+        failed: 3,
+        aborted: false,
+      });
+    }
+  );
+
+  t.test('Mixed 429 retry exhaustion preserves exact retry body and onDrop mappings', async (t) => {
+    let requestCount = 0;
+    let dropCount = 0;
+    const MockConnection = connection.buildMockConnection({
+      onRequest(params) {
+        t.equal(params.path, '/_bulk');
+        requestCount++;
+        if (requestCount === 2) {
+          const lines = params.body.split('\n').filter(Boolean);
+          t.equal(lines.length, 5);
+          t.same(JSON.parse(lines[0]), { index: { _index: 'test' } });
+          t.same(JSON.parse(lines[1]), { user: 'jon', age: 23 });
+          t.same(JSON.parse(lines[2]), { delete: { _index: 'test', _id: 1 } });
+          t.same(JSON.parse(lines[3]), { index: { _index: 'test' } });
+          t.same(JSON.parse(lines[4]), { user: 'tyrion', age: 39 });
+        }
+        return {
+          body: {
+            took: 0,
+            errors: true,
+            items: [
+              { index: { status: 429 } },
+              { delete: { status: 429 } },
+              { index: { status: 429 } },
+            ],
+          },
+        };
+      },
+    });
+
+    const client = new Client({
+      node: 'http://localhost:9200',
+      Connection: MockConnection,
+    });
+    const result = await client.helpers.bulk({
+      datasource: dataset.slice(),
+      flushBytes: 5000000,
+      concurrency: 1,
+      wait: 10,
+      retries: 1,
+      onDocument(doc) {
+        if (doc.user === 'arya') {
+          return {
+            delete: { _index: 'test', _id: 1 },
+          };
+        }
+        return {
+          index: { _index: 'test' },
+        };
+      },
+      onDrop(doc) {
+        dropCount++;
+        if (dropCount === 1) {
+          t.same(doc, {
+            status: 429,
+            error: null,
+            operation: { index: { _index: 'test' } },
+            document: { user: 'jon', age: 23 },
+            retried: true,
+          });
+        } else if (dropCount === 2) {
+          t.same(doc, {
+            status: 429,
+            error: null,
+            operation: { delete: { _index: 'test', _id: 1 } },
+            document: null,
+            retried: true,
+          });
+        } else if (dropCount === 3) {
+          t.same(doc, {
+            status: 429,
+            error: null,
+            operation: { index: { _index: 'test' } },
+            document: { user: 'tyrion', age: 39 },
+            retried: true,
+          });
+        }
+      },
+    });
+
+    t.equal(requestCount, 2);
+    t.equal(dropCount, 3);
+    t.type(result.time, 'number');
+    t.type(result.bytes, 'number');
+    t.match(result, {
+      total: 3,
+      successful: 0,
+      retry: 5,
+      failed: 3,
+      aborted: false,
+    });
+  });
+
+  t.end();
+});
+
 test('transport options', (t) => {
   t.test('Should pass transport options in request', async (t) => {
     let count = 0;


### PR DESCRIPTION
## Description

- Track cumulative request-body position so mixed one-line delete and two-line index/create/update operations map to correct bulk response items.
- Traverse exhausted 429 retry bodies using same variable-width operation sizes.
- Follow proven fix from https://github.com/elastic/elasticsearch-js/pull/1759.

Closes #1125

## Testing

- `npx eslint lib/Helpers.js test/unit/helpers/bulk.test.js`
- `npx tap test/unit/helpers/bulk.test.js --no-coverage`

## Checklist

- [x] Regression tests added
- [x] Lint passes
- [x] Commits include DCO signoff
- [x] Changelog updated