### PR TITLE
[Bug] Fix invalid extends syntax generated for nested allOf inside object properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Api Generator: fix invalid extends syntax generated for nested allOf inside object properties ([#1128](https://github.com/opensearch-project/opensearch-js/pull/1128))
 ### Security
 
 ## [3.6.0]

--- a/api_generator/src/renderers/render_types/TypesFileRenderder.ts
+++ b/api_generator/src/renderers/render_types/TypesFileRenderder.ts
@@ -28,7 +28,7 @@ export default class TypesFileRenderder extends BaseRenderer {
     return {
       is_function: this._container.is_function,
       types: _.entries(this._container.schemas).map(([name, schema]) => {
-        const definition = this.#render_schema(schema)
+        const definition = this.#render_schema(schema, true)
         const is_interface = definition.startsWith('extends')
         return { name, definition, is_interface }
       }),
@@ -40,7 +40,7 @@ export default class TypesFileRenderder extends BaseRenderer {
     }
   }
 
-  #render_schema (schema: Schema): string {
+  #render_schema (schema: Schema, is_top_level = false): string {
     if (schema.anyOf != null) schema.oneOf = schema.anyOf
     if (Array.isArray(schema.items)) throw new Error('Unhandled positioned array schema')
     if (_.isEmpty(schema)) return 'any'
@@ -57,7 +57,7 @@ export default class TypesFileRenderder extends BaseRenderer {
     if (Array.isArray(schema.type)) return schema.type.map(type => this.#render_schema({ type } satisfies Schema)).join(' | ')
     if (schema.type != null && schema.type !== 'object') throw new Error(`Unhandled schema type: ${(schema as any).type}`)
     if (schema.oneOf != null) return this.#render_oneOf(schema.oneOf as Schema[])
-    if (schema.allOf != null) return this.#render_allOf(schema.allOf as Schema[])
+    if (schema.allOf != null) return this.#render_allOf(schema.allOf as Schema[], is_top_level)
     return this.#render_simple_obj(schema)
   }
 
@@ -66,7 +66,7 @@ export default class TypesFileRenderder extends BaseRenderer {
     return this.#union(renders)
   }
 
-  #render_allOf (schemas: Schema[]): string {
+  #render_allOf (schemas: Schema[], is_top_level = false): string {
     const named_schemas = schemas.filter(schema => schema.$ref != null)
     const one_of_schemas = schemas.filter(schema => schema.oneOf != null)
     const component_schemas = schemas.filter(schema => (schema.$ref ?? schema.oneOf) == null)
@@ -85,7 +85,7 @@ export default class TypesFileRenderder extends BaseRenderer {
     if (inline_schemas.length === 0) return named_render
     if (named_schemas.length === 0) return inline_render
 
-    if (inline_render.includes('{') && this._container.is_function) return `extends ${named_render} ${inline_render}`
+    if (is_top_level && inline_render.includes('{') && this._container.is_function) return `extends ${named_render} ${inline_render}`
     else return this.#intersection([named_render, inline_render])
   }
 


### PR DESCRIPTION
### Description
The type generator (`api_generator/src/renderers/render_types/TypesFileRenderder.ts`) produces syntactically invalid TypeScript when a schema uses `allOf` (a named `$ref` combined with an inline object) inside a property's type position, rather than as the top-level definition of a type.

Example — explain's response body (get field, which combines InlineGet with an inline _source override):
```
npm run generate_api
// Before (invalid TypeScript, does not compile):

export type Explain_ResponseBody = {
  _id: Common.Id;
  _index: Common.IndexName;
  _type?: Common.Type;
  explanation?: Core_Explain.Explanation;
  get?: extends Common.InlineGet {
  _source?: Common.TDocument;
};
  matched: boolean;
}
```

```
dev-dsk-yubonluo-2a-667699e4 % yarn run test:types
yarn run v1.22.22
$ tsd
Error running tsd: Error: 
  api/_core/explain.d.ts:55:8
  ✖  55:8   Cannot find name extends.                                                                                          
  ✖  55:16  ; expected.                                                                                                        
  ✖  55:23  Property InlineGet does not exist on type typeof import("/local/home/yubonluo/opensearch-js/api/_types/_common").  
  ✖  55:33  ; expected.                                                                                                        
  ✖  56:2   Cannot find name _source.                                                                                          
  ✖  56:10  Expression expected.                                                                                               
  ✖  56:19  Property TDocument does not exist on type typeof import("/local/home/yubonluo/opensearch-js/api/_types/_common").  
  ✖  58:11  boolean only refers to a type, but is being used as a value here.                                                  
  ✖  59:0   Declaration or statement expected.                                                                                 

  9 errors

    at /local/home/yubonluo/opensearch-js/node_modules/tsd/dist/cli.js:64:19
    at Generator.next (<anonymous>)
    at fulfilled (/local/home/yubonluo/opensearch-js/node_modules/tsd/dist/cli.js:6:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
`extends X Y { ... }` is only valid as the top-level definition of an `export interface Name extends X Y { ... }` declaration. It can never appear as the type of an object property. This same bug likely affects any function response/request type where an allOf schema is nested inside another object's property (not just explain).

After fix:
```
export type Explain_ResponseBody = {
  _id: Common.Id;
  _index: Common.IndexName;
  _type?: Common.Type;
  explanation?: Core_Explain.Explanation;
  get?: Common.InlineGet & {
  _source?: Common.TDocument;
};
  matched: boolean;
}
```
```
dev-dsk-yubonluo-2a-667699e4 % yarn run test:types
yarn run v1.22.22
$ tsd
Done in 4.16s.
```

### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
