### PR TITLE
Replace GitHub App token with opensearch-ci-bot PAT in generate_api workflow

### DIFF
--- a/.github/workflows/generate_api.yml
+++ b/.github/workflows/generate_api.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          push-to-fork: opensearch-ci-bot/opensearch-js
+          token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           commit-message: "Updated opensearch-js to reflect the latest OpenSearch API spec (${{ env.date }})"
           title: "[AUTOCUT] Update opensearch-js to reflect the latest OpenSearch API spec (${{ env.date }})"
           body: |

--- a/.github/workflows/generate_api.yml
+++ b/.github/workflows/generate_api.yml
@@ -39,17 +39,10 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - name: GitHub App token
-        id: github_app_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Create pull request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          token: ${{ steps.github_app_token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Updated opensearch-js to reflect the latest OpenSearch API spec (${{ env.date }})"
           title: "[AUTOCUT] Update opensearch-js to reflect the latest OpenSearch API spec (${{ env.date }})"
           body: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Api Generator: fix invalid extends syntax generated for nested allOf inside object properties ([#1128](https://github.com/opensearch-project/opensearch-js/pull/1128))
+- Fix generate_api workflow: replace revoked GitHub App token with GITHUB_TOKEN ([#1130]https://github.com/opensearch-project/opensearch-js/pull/1130)
 ### Security
 
 ## [3.6.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Api Generator: fix invalid extends syntax generated for nested allOf inside object properties ([#1128](https://github.com/opensearch-project/opensearch-js/pull/1128))
-- Fix generate_api workflow: replace revoked GitHub App token with GITHUB_TOKEN ([#1130]https://github.com/opensearch-project/opensearch-js/pull/1130)
+- Replace GitHub App token with opensearch-ci-bot PAT in generate_api workflow ([#1130](https://github.com/opensearch-project/opensearch-js/pull/1130))
 ### Security
 
 ## [3.6.0]


### PR DESCRIPTION
### Description

The `generate_api` workflow was failing because the GitHub App credentials (`APP_ID` / `APP_PRIVATE_KEY`) have been permanently revoked following the opensearch-js security incident.

This PR replaces the `tibdex/github-app-token` step with the `opensearch-ci-bot` PAT and uses the `push-to-fork` strategy to create auto-generated API update PRs.

### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
