### PR TITLE
Api Generator: Lazily instantiate API namespaces to fix Client construction performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Api Generator: fix invalid extends syntax generated for nested allOf inside object properties ([#1128](https://github.com/opensearch-project/opensearch-js/pull/1128))
 - Replace GitHub App token with opensearch-ci-bot PAT in generate_api workflow ([#1130](https://github.com/opensearch-project/opensearch-js/pull/1130))
+- Api Generator: Lazily instantiate API namespaces to fix Client construction performance ([#1133](https://github.com/opensearch-project/opensearch-js/pull/1133))
 ### Security
 - Fix CVEs in diff, lodash, and yaml dependencies ([#1131] https://github.com/opensearch-project/opensearch-js/pull/1131)
 

--- a/api_generator/src/renderers/templates/OpensearchAPI.mustache
+++ b/api_generator/src/renderers/templates/OpensearchAPI.mustache
@@ -6,35 +6,46 @@
 const { kConfigErr } = require('./utils')
 const kApiModules = Symbol('api modules')
 
+// Namespace constructors and root function modules are required once at
+// module load time (not per Client instance) to avoid paying `require()`
+// resolution cost (and any installed require-hook overhead, e.g. APM/OTel
+// auto-instrumentation) on every `new Client()` / `client.child()` call.
+{{#api_modules}}
+const {{{prototype_name}}}Ctor = require('{{{path}}}');
+{{/api_modules}}
+
+{{#root_functions}}
+const {{{prototype_name}}}Fn = require('{{{path}}}');
+{{/root_functions}}
+
 class OpenSearchAPI {
   constructor (opts) {
     this[kConfigErr] = opts.ConfigurationError
-    this[kApiModules] = {
-      {{#api_modules}}
-      {{{prototype_name}}}: new(require('{{{path}}}'))(this),
-      {{/api_modules}}
-    }
+    this[kApiModules] = {}
 
     // Setup Root API Functions
     /** @namespace {{{doc_namespace}}} */
     {{#root_functions}}
-    this.{{{prototype_name}}} = require('{{{path}}}').bind(this)
+    this.{{{prototype_name}}} = {{{prototype_name}}}Fn.bind(this)
     {{/root_functions}}
 
     {{#deprecated_root_functions}}
     // Deprecated: Use {{{prototype_name}}} instead.
-    this.{{{snake_cased_name}}} = require('{{{path}}}').bind(this)
+    this.{{{snake_cased_name}}} = {{{prototype_name}}}Fn.bind(this)
     {{/deprecated_root_functions}}
 
     // Setup API Modules
+    // Each namespace is instantiated lazily on first access
+    const kApiModulesMap = this[kApiModules]
+    const self = this
     Object.defineProperties(this, {
     {{#api_modules}}
-      {{{prototype_name}}}: { get() { return this[kApiModules].{{{prototype_name}}} } },
+      {{{prototype_name}}}: { get() { return kApiModulesMap.{{{prototype_name}}} ?? (kApiModulesMap.{{{prototype_name}}} = new {{{prototype_name}}}Ctor(self)) } },
     {{/api_modules}}
 
     {{#deprecated_api_modules}}
       // Deprecated: Use {{{prototype_name}}} instead.
-      {{{snake_cased_name}}}: { get() { return this[kApiModules].{{{prototype_name}}} } },
+      {{{snake_cased_name}}}: { get() { return kApiModulesMap.{{{prototype_name}}} ?? (kApiModulesMap.{{{prototype_name}}} = new {{{prototype_name}}}Ctor(self)) } },
     {{/deprecated_api_modules}}
     })
   }

--- a/api_generator/src/renderers/templates/module.mustache
+++ b/api_generator/src/renderers/templates/module.mustache
@@ -5,14 +5,21 @@
 
 /** @namespace {{doc_namespace}} */
 
+// All operation modules are required once at module load time (not per
+// instance) to avoid paying `require()` resolution cost on every Client
+// construction.
+{{#functions}}
+const {{{prototype_name}}}Fn = require('{{{path}}}');
+{{/functions}}
+
 function {{{module_name}}}(bindObj) {
   {{#functions}}
-  this.{{{prototype_name}}} = require('{{{path}}}').bind(bindObj);
+  this.{{{prototype_name}}} = {{{prototype_name}}}Fn.bind(bindObj);
   {{/functions}}
 
   {{#deprecated_functions}}
   // Deprecated: Use {{{prototype_name}}} instead.
-  this.{{{snake_cased_name}}} = require('{{{path}}}').bind(bindObj);
+  this.{{{snake_cased_name}}} = {{{prototype_name}}}Fn.bind(bindObj);
   {{/deprecated_functions}}
 }
 


### PR DESCRIPTION
### Description

`new Client()` (and therefore `client.child()`, which calls `new Client()` internally) got 30-250x slower in 3.x compared to 2.x, because the generated `OpenSearchAPI` constructor eagerly `require()`s and instantiates every one of the ~40 API namespaces, and every namespace constructor eagerly `require()`s and `.bind()`s every one of its operations — **662 `require()` calls executed on every single `Client` construction**.

This is expensive on its own (every call still goes through `Module.require` resolution even when the module is cache-hit), and becomes catastrophic when any require-hooking tool is installed, because each of the 662 calls then also pays the hook's synchronous filesystem `stat` cost on the event loop.

This matters most for `client.child()`: **OpenSearch Dashboards core calls `client.child()` on every incoming HTTP request** (`ClusterClient.asScoped()` → `rootScopedClient.child(...)`), so every Dashboards-based deployment pays this cost per request. On a production Dashboards service upgraded from 2.13.0 to 3.6.0 with no other changes, this showed up as ~2x higher average latency under normal load and complete throughput collapse under load testing (CPU pegged at 4-5x normal, with 37% of all busy CPU attributed to the `Client.child()` subtree in a V8 profile).

This also contradicts the project's own 3.0 design goal (#803): "Lazy loading of API modules and functions... loaded on the fly as they are invoked for the first time." The generated code does define per-namespace getters (the lazy *shape*), but the backing `kApiModules` map was already fully populated by the constructor before the getters ever ran, so the getters provided no actual laziness.

**Fix**, applied in the two generator templates (and regenerated into `api/OpenSearchApi.js` and every `api/**/_api.js`):

- `api_generator/src/renderers/templates/module.mustache`: hoist every operation's `require(...)` to module load time (executed once, when the file is first `require`d) instead of inside the module constructor (executed on every `new XApi(bindObj)`). The constructor now only does the cheap `.bind(bindObj)`.
- `api_generator/src/renderers/templates/OpensearchAPI.mustache`: hoist every namespace constructor's `require(...)` to module load time, and make `kApiModules` populate **lazily inside the existing getters** (`kApiModulesMap.foo ?? (kApiModulesMap.foo = new fooCtor(self))`) instead of eagerly in the constructor. This makes the pre-existing getter shape actually lazy, matching 2.x behavior and the #803 design intent.

No public API, method signature, or error-handling behavior changes. `client.extend()` (including extending into an existing lazy namespace) and snake_case deprecated aliases continue to work unmodified.

### Benchmark

Reproduction of the issue's own micro-benchmark (`client.child()` x200, Node.js v22, steady state / warm require cache):

| Scenario | Before (v3.6.0) | After (this fix) |
|---|---|---|
| No require-hook | 0.41–0.45 ms/call | **0.06 ms/call** |
| With a `require-in-the-middle` hook (simulates an APM/OTel agent) | 4.38–5.98 ms/call | **0.06 ms/call** |
| Reference: v2.13.0 baseline | 0.02 ms/call (both scenarios) | — |

The fix eliminates the require-hook amplification entirely (0.06 ms/call regardless of hooking, since `client.child()` no longer triggers any `require()` calls after the module has loaded once). A small residual gap remains vs. v2.13.0's 0.02 ms/call, from `.bind()` allocation on root functions — a separate, smaller optimization (moving root functions to the prototype, as 2.x does) that is out of scope here: 2.x's prototype approach does not support destructured calls (`const { bulk } = client; bulk(...)`), whereas 3.x's current `.bind()`-per-instance approach does, so removing it would be a behavior change beyond what #1132 reports.

### Verification

- `yarn run lint` / `eslint`: clean on all changed files.
- `npm run test:types` (tsd): clean.
- `npm run test:unit` / `npm run test:acceptance`: all suites pass, 0 failures.
- Manual regression check (23 assertions) covering: root-function calls, lazy-namespace singleton/isolation semantics across multiple `Client` instances, `client.child()` (including 50 rapid successive calls simulating the Dashboards per-request pattern), `client.extend()` into both new and existing lazy namespaces, extension propagation through `child()`, deprecated snake_case aliases, and error-handling (Promise/callback styles) — all passed, no behavior change found.
- Manual end-to-end check against a real local OpenSearch 3.7.0 cluster: `info()`, `bulk()`, `search()`, `cat.health()`, `security.authinfo()` (lazy namespace), and `child().info()` — all passed.

### Issues Resolved

Closes #1132


### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
