### PR TITLE
fix(bundler-test): Upgrade webpack to v5 in bundler test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Api Generator: fix invalid extends syntax generated for nested allOf inside object properties ([#1128](https://github.com/opensearch-project/opensearch-js/pull/1128))
 - Replace GitHub App token with opensearch-ci-bot PAT in generate_api workflow ([#1130](https://github.com/opensearch-project/opensearch-js/pull/1130))
 - Api Generator: Lazily instantiate API namespaces to fix Client construction performance ([#1133](https://github.com/opensearch-project/opensearch-js/pull/1133))
+- Upgrade webpack to v5 in bundler test to support the nullish coalescing operator emitted by the API generator ([#1138](https://github.com/opensearch-project/opensearch-js/pull/1138))
 ### Security
 - Fix CVEs in diff, lodash, and yaml dependencies ([#1131] https://github.com/opensearch-project/opensearch-js/pull/1131)
 

--- a/test/bundlers/webpack-test/package.json
+++ b/test/bundlers/webpack-test/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "webpack": "^4.44.2",
-    "webpack-cli": "^3.3.12"
+    "webpack": "^5.94.0",
+    "webpack-cli": "^5.1.4"
   }
 }


### PR DESCRIPTION
### Description
webpack 4's bundled acorn parser does not support the nullish coalescing operator (??), which is now emitted by the API generator's lazy-getter pattern for API namespace instantiation (see #1133). This caused the Bundler workflow's webpack-test build step to fail with 'Module parse failed: Unexpected token' on api/OpenSearchApi.js.

Upgrade webpack ^4.44.2 -> ^5.94.0 and webpack-cli ^3.3.12 -> ^5.1.4, both of which support ES2020+ syntax by default. Verified locally: npm install && npm run build succeeds, producing bundle.js with no parse errors (webpack 5.109.2).
### Issues Resolved

_List any issues this PR will resolve, e.g. Closes [...]._

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] Linter check was successfull - `yarn run lint` doesn't show any errors
- [ ] Commits are signed per the DCO using --signoff
- [ ] Changelog was updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
