### PR TITLE
fix: update API spec download URL to api-spec.opensearch.org

### DIFF
--- a/.github/workflows/generate_api.yml
+++ b/.github/workflows/generate_api.yml
@@ -47,7 +47,7 @@ jobs:
           commit-message: "Updated opensearch-js to reflect the latest OpenSearch API spec (${{ env.date }})"
           title: "[AUTOCUT] Update opensearch-js to reflect the latest OpenSearch API spec (${{ env.date }})"
           body: |
-            Update `opensearch-js` to reflect the latest [OpenSearch API spec](https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml).
+            Update `opensearch-js` to reflect the latest [OpenSearch API spec](https://api-spec.opensearch.org/opensearch-openapi.yaml).
             Date: ${{ env.date }}
           branch: update-api-from-spec-${{ env.date }}
           base: main

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "file:///github/workspace/*" --exclude-mail
+          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "file:///github/workspace/*" --exclude "https://api-spec.opensearch.org/opensearch-openapi.yaml" --exclude-mail
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Dependencies
 ### Changed
+- Updated API spec download URL to `https://api-spec.opensearch.org` ([#1141](https://github.com/opensearch-project/opensearch-js/pull/1141))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/api_generator/package.json
+++ b/api_generator/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "generate_api": "ts-node src/generate_api.ts",
-    "download_spec": "curl -L -X GET \"https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml\" -o opensearch-openapi.yaml",
+    "download_spec": "curl -L -X GET \"https://api-spec.opensearch.org/opensearch-openapi.yaml\" -o opensearch-openapi.yaml",
     "lint": "eslint . --report-unused-disable-directives",
     "lint--fix": "eslint . --fix --report-unused-disable-directives"
   },


### PR DESCRIPTION
### Description

Update the OpenAPI spec download URL from the GitHub release assets URL to the new canonical location at `https://api-spec.opensearch.org/opensearch-openapi.yaml`.

The `opensearch-api-specification` repo now publishes the spec at this new URL (see opensearch-project/opensearch-api-specification#1200).

### Changes

- `api_generator/package.json`: Updated `download_spec` curl URL
- `.github/workflows/generate_api.yml`: Updated URL in PR body template

### Related

- opensearch-project/opensearch-api-specification#1200
- opensearch-project/opensearch-php#420
- opensearch-project/opensearch-net#1030

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).